### PR TITLE
added sbt-spark-package support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,18 +4,20 @@ name := "spark-testing-base"
 
 publishMavenStyle := true
 
-version := "0.0.1"
+version := "0.0.2"
 
 scalaVersion := "2.10.4"
 
 javacOptions ++= Seq("-source", "1.7", "-target", "1.7")
 
+spName := "holdenk/spark-testing-base"
+
+sparkVersion := "1.1.1"
+
+sparkComponents ++= Seq("core", "streaming")
+
 // additional libraries
-libraryDependencies ++= Seq(
-  "org.apache.spark" %% "spark-core" % "1.1.1" % "provided",
-  "org.apache.spark" %% "spark-streaming" % "1.1.1" % "provided",
-  "org.scalatest" %% "scalatest" % "2.2.1"
-)
+libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.1"
 
 scalacOptions ++= Seq("-deprecation", "-unchecked")
 
@@ -45,7 +47,7 @@ publishTo := {
     Some("releases"  at nexus + "service/local/staging/deploy/maven2")
 }
 
-licenses := Seq("Apache 2.0 License" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
+licenses := Seq("Apache License 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 
 homepage := Some(url("https://github.com/holdenk/spark-testing-base"))
 
@@ -64,3 +66,5 @@ pomExtra := (
     </developer>
   </developers>
 )
+
+credentials += Credentials(Path.userHome / ".ivy2" / ".sbtcredentials")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,7 @@
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.6.0")
 
 resolvers += "sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/"
+
+resolvers += "Spark Package Main Repo" at "https://dl.bintray.com/spark-packages/maven"
+
+addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.0")


### PR DESCRIPTION
Yaayyy! All you need to do is add a credentials file to `~/.ivy2/.sbtcredentials` that looks like:
```
realm=Spark Packages API
host=spark-packages.org
user=holdenk
password=$GITHUB_PERSONAL_ACCESS_TOKEN
```
Replace `$GITHUB_PERSONAL_ACCESS_TOKEN` with a personal access token with `read:org` scope. How to generate one is documented [here](https://help.github.com/articles/creating-an-access-token-for-command-line-use/).

Once that's done, just run `sbt spPublish` and you're done!

Enjoy!