### PR TITLE
Fix NPE With Multiple Tests 

### DIFF
--- a/src/main/scala/com/holdenkarau/spark/testing/StreamingSuiteBase.scala
+++ b/src/main/scala/com/holdenkarau/spark/testing/StreamingSuiteBase.scala
@@ -143,7 +143,7 @@ trait StreamingSuiteBase extends FunSuite with BeforeAndAfterAll with Logging
       block(outputStream, ssc)
     } finally {
       try {
-        ssc.stop(stopSparkContext = true)
+        ssc.stop(stopSparkContext = false)
       } catch {
         case e: Exception =>
           logError("Error stopping StreamingContext", e)
@@ -251,7 +251,7 @@ trait StreamingSuiteBase extends FunSuite with BeforeAndAfterAll with Logging
 
       Thread.sleep(100) // Give some time for the forgetting old RDDs to complete
     } finally {
-      ssc.stop(stopSparkContext = true)
+      ssc.stop(stopSparkContext = false)
     }
     output.toSeq
   }


### PR DESCRIPTION
Fixes #2 by keeping the SparkContext open.   Looks to me like SharedSparkContext will stop it after all tests in the suite have run.