### PR TITLE
Create static SqlContext at DataFrameSuiteBase

### DIFF
--- a/src/main/1.3/scala/com/holdenkarau/spark/testing/DataFrameSuiteBase.scala
+++ b/src/main/1.3/scala/com/holdenkarau/spark/testing/DataFrameSuiteBase.scala
@@ -52,9 +52,7 @@ trait DataFrameSuiteBase extends DataFrameSuiteBaseLike with SharedSparkContext 
 
 trait DataFrameSuiteBaseLike extends FunSuiteLike with SparkContextProvider with Serializable {
 
-  @transient var _sqlContext: HiveContext = _
-
-  def sqlContext: HiveContext = _sqlContext
+  def sqlContext: HiveContext = SQLContextProvider._sqlContext
 
   def beforeAllTestCases() {
     /** Constructs a configuration for hive, where the metastore is located in a temp directory. */
@@ -92,15 +90,17 @@ trait DataFrameSuiteBaseLike extends FunSuiteLike with SparkContextProvider with
 
       propMap.toMap
     }
+
     val config = newTemporaryConfiguration()
     class TestHiveContext(sc: SparkContext) extends HiveContext(sc) {
       override def configure(): Map[String, String] = config
     }
-    _sqlContext = new HiveContext(sc)
+
+    SQLContextProvider._sqlContext = new TestHiveContext(sc)
   }
 
   def afterAllTestCases() {
-    _sqlContext = null
+    SQLContextProvider._sqlContext = null
   }
 
   /**
@@ -227,4 +227,8 @@ object DataFrameSuiteBase {
     }
     true
   }
+}
+
+object SQLContextProvider {
+    @transient var _sqlContext: HiveContext = _
 }

--- a/src/test/1.3/scala/com/holdenkarau/spark/testing/MultipleDataFrameSuites.scala
+++ b/src/test/1.3/scala/com/holdenkarau/spark/testing/MultipleDataFrameSuites.scala
@@ -1,0 +1,7 @@
+package com.holdenkarau.spark.testing
+
+class MultipleDataFrameSuites extends DataFrameSuiteBase {
+  test("test nothing") {
+    assert(1 === 1)
+  }
+}


### PR DESCRIPTION
Sql Context should be static as in Java unit tests non static variables
will be initialzed before every test case