### PR TITLE
Set number of batches to length of input list

### DIFF
--- a/src/main/1.3/scala/com/holdenkarau/spark/testing/StreamingSuiteBase.scala
+++ b/src/main/1.3/scala/com/holdenkarau/spark/testing/StreamingSuiteBase.scala
@@ -119,7 +119,7 @@ trait StreamingSuiteBase extends FunSuite with BeforeAndAfterAll with Logging
 
   /**
     * Test unary DStream operation with a list of inputs, with number of
-    * batches to run same as the number of expected output values
+    * batches to run same as the number of input values
     *
     * @param ordered Compare the output values with the expected output values ordered or not.
     *                Comparing doubles may not work well in case of unordered.
@@ -134,7 +134,8 @@ trait StreamingSuiteBase extends FunSuite with BeforeAndAfterAll with Logging
   }
 
   /**
-    * Test unary DStream operation with a list of inputs
+    * Test unary DStream operation with a list of inputs.
+    *
     * @param input      Sequence of input collections
     * @param operation  Binary DStream operation to be applied to the 2 inputs
     * @param expectedOutput Sequence of expected output collections
@@ -149,7 +150,8 @@ trait StreamingSuiteBase extends FunSuite with BeforeAndAfterAll with Logging
     numBatches: Int,
     ordered: Boolean
   ) (implicit equality: Equality[V]) {
-    val numBatches_ = if (numBatches > 0) numBatches else expectedOutput.size
+    val numBatches_ = if (numBatches > 0) numBatches else input.size
+
     withOutputAndStreamingContext(setupStreams[U, V](input, operation)) { (outputStream, ssc) =>
       val output: Seq[Seq[V]] = runStreams[V](outputStream, ssc, numBatches_, expectedOutput.size)
       verifyOutput[V](output, expectedOutput, ordered)
@@ -158,7 +160,7 @@ trait StreamingSuiteBase extends FunSuite with BeforeAndAfterAll with Logging
 
   /**
     * Test binary DStream operation with two lists of inputs, with number of
-    * batches to run same as the number of expected output values
+    * batches to run same as the number of input values. The size of the two input lists Should be the same.
     *
     * @param ordered Compare the output values with the expected output values ordered or not.
     *                Comparing doubles may not work well in case of unordered.
@@ -174,7 +176,8 @@ trait StreamingSuiteBase extends FunSuite with BeforeAndAfterAll with Logging
   }
 
   /**
-    * Test binary DStream operation with two lists of inputs
+    * Test binary DStream operation with two lists of inputs. The size of the two input lists Should be the same.
+    *
     * @param input1     First sequence of input collections
     * @param input2     Second sequence of input collections
     * @param operation  Binary DStream operation to be applied to the 2 inputs
@@ -191,7 +194,10 @@ trait StreamingSuiteBase extends FunSuite with BeforeAndAfterAll with Logging
     numBatches: Int,
     ordered: Boolean
   ) (implicit equality: Equality[W]) {
-    val numBatches_ = if (numBatches > 0) numBatches else expectedOutput.size
+    assert(input1.length === input2.length, "Length of the input lists are not equal")
+
+    val numBatches_ = if (numBatches > 0) numBatches else input1.size
+
     withOutputAndStreamingContext(setupStreams[U, V, W](input1, input2, operation)) {
       (outputStream, ssc) =>
       val output = runStreams[W](outputStream, ssc, numBatches_, expectedOutput.size)

--- a/src/main/1.3/scala/com/holdenkarau/spark/testing/StreamingSuiteBase.scala
+++ b/src/main/1.3/scala/com/holdenkarau/spark/testing/StreamingSuiteBase.scala
@@ -139,7 +139,7 @@ trait StreamingSuiteBase extends FunSuite with BeforeAndAfterAll with Logging
     * @param input      Sequence of input collections
     * @param operation  Binary DStream operation to be applied to the 2 inputs
     * @param expectedOutput Sequence of expected output collections
-    * @param numBatches Number of batches to run the operation for
+    * @param numBatches Number of batches to run the operation for. Should be less than or equal input length.
     * @param ordered Compare the output values with the expected output values ordered or not.
     *                Comparing doubles may not work well in case of unordered.
     */
@@ -150,6 +150,8 @@ trait StreamingSuiteBase extends FunSuite with BeforeAndAfterAll with Logging
     numBatches: Int,
     ordered: Boolean
   ) (implicit equality: Equality[V]) {
+    assert(numBatches <= input.length, "number of batches can't be greater than input length")
+
     val numBatches_ = if (numBatches > 0) numBatches else input.size
 
     withOutputAndStreamingContext(setupStreams[U, V](input, operation)) { (outputStream, ssc) =>
@@ -182,7 +184,7 @@ trait StreamingSuiteBase extends FunSuite with BeforeAndAfterAll with Logging
     * @param input2     Second sequence of input collections
     * @param operation  Binary DStream operation to be applied to the 2 inputs
     * @param expectedOutput Sequence of expected output collections
-    * @param numBatches Number of batches to run the operation for
+    * @param numBatches Number of batches to run the operation for. Should be less than or equal input length.
     * @param ordered Compare the output values with the expected output values ordered or not.
     *                Comparing doubles may not work well in case of unordered.
     */
@@ -195,6 +197,7 @@ trait StreamingSuiteBase extends FunSuite with BeforeAndAfterAll with Logging
     ordered: Boolean
   ) (implicit equality: Equality[W]) {
     assert(input1.length === input2.length, "Length of the input lists are not equal")
+    assert(numBatches <= input1.length, "number of batches can't be greater than input length")
 
     val numBatches_ = if (numBatches > 0) numBatches else input1.size
 

--- a/src/test/1.3/scala/com/holdenkarau/spark/testing/SampleStreamingTest.scala
+++ b/src/test/1.3/scala/com/holdenkarau/spark/testing/SampleStreamingTest.scala
@@ -17,6 +17,7 @@
 package com.holdenkarau.spark.testing
 
 import org.apache.spark.rdd.RDD
+import org.apache.spark.streaming.Seconds
 import org.apache.spark.streaming.dstream._
 import org.scalactic.Equality
 import org.scalatest.exceptions.TestFailedException
@@ -56,7 +57,7 @@ class SampleStreamingTest extends StreamingSuiteBase {
   test("a wrong expected multiset for a micro batch leads to a test fail") {
     val input = List(List("hi"), List("hi holden"), List("bye"))
     val badMultisetExpected = List(List("hi"), List("hi", "holden", "hi"), List("bye"))
-    val thrown = intercept[TestFailedException] {
+    intercept[TestFailedException] {
         testOperation[String, String](input, tokenize _, badMultisetExpected, ordered = false)
     }
   }
@@ -97,6 +98,34 @@ class SampleStreamingTest extends StreamingSuiteBase {
     testOperation[Int, Int](input, doNothing _, expected, ordered = true)
   }
 
+  test("CountByWindow with windowDuration 3s and slideDuration=2s") {
+    // There should be 2 windows :  {batch2, batch1},  {batch4, batch3, batch2}
+    val batch1 = List("a", "b")
+    val batch2 = List("d", "f", "a")
+    val batch3 = List("f", "g"," h")
+    val batch4 = List("a")
+    val input= List(batch1, batch2, batch3, batch4)
+    val expected = List(List(5L), List(7L))
+
+    def countByWindow(ds:DStream[String]):DStream[Long] = {
+      ds.countByWindow(windowDuration = Seconds(3), slideDuration = Seconds(2))
+    }
+
+    testOperation[String, Long](input, countByWindow _, expected, ordered = true)
+  }
+
+  test("two lists length should be equal") {
+    def nothing(stream1: DStream[Int], stream2: DStream[Int]) = stream1
+
+    val input1 = List(List(1), List(2))
+    val input2 = List(List(1), List(2), List(3))
+
+    val output = List(List(1), List(2), List(3))
+
+    intercept[TestFailedException] {
+      testOperation(input1, input2, nothing _, output, ordered = false)
+    }
+  }
 }
 
 object SampleStreamingTest {

--- a/src/test/1.3/scala/com/holdenkarau/spark/testing/SampleStreamingTest.scala
+++ b/src/test/1.3/scala/com/holdenkarau/spark/testing/SampleStreamingTest.scala
@@ -126,6 +126,18 @@ class SampleStreamingTest extends StreamingSuiteBase {
       testOperation(input1, input2, nothing _, output, ordered = false)
     }
   }
+
+  test("number of batches can't be greater than input length") {
+    def nothing(stream: DStream[Int]) = stream
+
+    val input = List(List(1), List(2))
+    val output = List(List(1), List(2))
+
+    intercept[TestFailedException] {
+      testOperation(input, nothing _, output, 100, ordered = false)
+    }
+  }
+
 }
 
 object SampleStreamingTest {


### PR DESCRIPTION
https://github.com/holdenk/spark-testing-base/issues/59

I think it's more logical that the number of batches = length of input size