### PR TITLE
Illustrate size control

### DIFF
--- a/src/test/1.3/scala/com/holdenkarau/spark/testing/SampleScalaCheckTest.scala
+++ b/src/test/1.3/scala/com/holdenkarau/spark/testing/SampleScalaCheckTest.scala
@@ -72,6 +72,15 @@ class SampleScalaCheckTest extends FunSuite with SharedSparkContext with Checker
     check(property)
   }
 
+  test("generate rdd of specific size") {
+    implicit val generatorDrivenConfig =
+      PropertyCheckConfig(minSize = 10, maxSize = 20)
+    val prop = forAll(RDDGenerator.genRDD[String](sc)(Arbitrary.arbitrary[String])){
+      rdd => rdd.count() <= 20
+    }
+    check(prop)
+  }
+
   def filterOne(rdd: RDD[String]): RDD[Int] = {
     rdd.filter(_.length > 2).map(_.length)
   }


### PR DESCRIPTION
Illustrate one of the ways we can specify the control sizes. We can also use resize.