### PR TITLE
Add Log4j properties file

### DIFF
--- a/src/main/1.5/scala/com/holdenkarau/spark/testing/SharedSparkContext.scala
+++ b/src/main/1.5/scala/com/holdenkarau/spark/testing/SharedSparkContext.scala
@@ -41,8 +41,6 @@ trait SharedSparkContext extends BeforeAndAfterAll with SparkContextProvider {
 
   override def beforeAll() {
     _sc = new SparkContext(conf)
-    _sc.setLogLevel(org.apache.log4j.Level.WARN.toString)
-
     super.beforeAll()
   }
 

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,0 +1,5 @@
+log4j.rootLogger = WARN, console
+log4j.appender.console = org.apache.log4j.ConsoleAppender
+log4j.appender.console.target = System.err
+log4j.appender.console.layout = org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern = %d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n


### PR DESCRIPTION
Set log level in this log4.properties file instead of calling sparkContext.setLogLevel
This is compatible with all spark versions