### PR TITLE
Add method to clearLocalRootDirs

### DIFF
--- a/src/main/1.3/scala/com/holdenkarau/spark/testing/LocalSparkContext.scala
+++ b/src/main/1.3/scala/com/holdenkarau/spark/testing/LocalSparkContext.scala
@@ -59,4 +59,5 @@ object LocalSparkContext {
     }
   }
 
+  def clearLocalRootDirs(): Unit = SparkUtils.clearLocalRootDirs()
 }

--- a/src/main/1.3/scala/org/apache/spark/SparkUtils.scala
+++ b/src/main/1.3/scala/org/apache/spark/SparkUtils.scala
@@ -1,0 +1,9 @@
+package org.apache.spark
+
+import org.apache.spark.util.Utils
+
+object SparkUtils {
+  def clearLocalRootDirs(): Unit = {
+    Utils.clearLocalRootDirs()
+  }
+}


### PR DESCRIPTION
https://github.com/holdenk/spark-testing-base/issues/13

I added a method in `LocalSparkContext` to clear LocalRootDirs. I think it's better to just leave it like this and give the user the flexibility to use it whenever he wants. For ex. if he wants to use it after each test case, just call it after each test case. What do you think ?