### PR TITLE
Changed generator for Timestamps and Dates to fix changing timestamps…

### DIFF
--- a/src/main/1.3/scala/com/holdenkarau/spark/testing/DataframeGenerator.scala
+++ b/src/main/1.3/scala/com/holdenkarau/spark/testing/DataframeGenerator.scala
@@ -88,8 +88,8 @@ object DataframeGenerator {
       case StringType => Arbitrary.arbitrary[String]
       case BinaryType => Arbitrary.arbitrary[Array[Byte]]
       case BooleanType => Arbitrary.arbitrary[Boolean]
-      case TimestampType => Arbitrary.arbDate.arbitrary.map(time => new Timestamp(time.getTime))
-      case DateType => Arbitrary.arbDate.arbitrary.map(time => new Date(time.getTime))
+      case TimestampType => Arbitrary.arbLong.arbitrary.map(new Timestamp(_))
+      case DateType => Arbitrary.arbLong.arbitrary.map(new Date(_))
       case arr: ArrayType => {
         val elementGenerator = getGenerator(arr.elementType)
         return Gen.listOf(elementGenerator)


### PR DESCRIPTION
… causing failing equals check

* Using arbDate caused timestamps to change every time the dataframe was evaluated.
* Using arbLong fixes this problem
* Changed date generator to prevent the edge case of arbDate rolling over midnight between evaluations, which could have caused equals check to fail