### PR TITLE
Add support for DStream and RDD operations.

### DIFF
--- a/src/test/1.3/scala/com/holdenkarau/spark/testing/SampleStreamingTest.scala
+++ b/src/test/1.3/scala/com/holdenkarau/spark/testing/SampleStreamingTest.scala
@@ -138,6 +138,14 @@ class SampleStreamingTest extends FunSuite with StreamingSuiteBase {
     testOperation(input1, multiply _, output, ordered = false)
   }
 
+  test("stream and batch transformation") {
+    def intersection(f1: DStream[String], f2: RDD[String]) = f1.transform(_.intersection(f2))
+
+    val stream = List(List("hi"), List("holden"), List("bye"))
+    val batch = List("holden")
+    val expected = List(List(), List("holden"), List())
+    testOperationWithRDD[String, String, String](stream, batch, intersection _, expected, ordered = false)
+  }
 }
 
 object SampleStreamingTest {


### PR DESCRIPTION
This PR covers the scenario where a `DStream` and a `RDD` are joined using `transform` operation. 

Unfortunately I wasn't able to follow `testOperation` convention, since Scala type erasure. New method changes the type of `input2` to `Seq[V]` and `operation` to `(DStream[U], RDD[V]) => DStream[W])`. However after type erasure those types are `Seq` and `Function2`, so compiler thinks that there is a collision on signatures.  

Suggested name for the new method is `testOperationWithRDD`.