### PR TITLE
Set the spark 2.0 warehouse directory

### DIFF
--- a/src/main/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteBase.scala
+++ b/src/main/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteBase.scala
@@ -76,6 +76,8 @@ trait DataFrameSuiteBaseLike extends SparkContextProvider with TestSuiteLike wit
       builder.config(ConfVars.METASTOREURIS.varname, "")
       builder.config("spark.sql.streaming.checkpointLocation",
         Utils.createTempDir().toPath().toString)
+      builder.config("spark.sql.warehouse.dir",
+        localWarehousePath)
     }
 
     SparkSessionProvider._sparkSession = newBuilder().getOrCreate()


### PR DESCRIPTION
The Spark 2.0 implementation does not set the warehouse directory. When running in windows, this resulted in the error:

```
java.lang.IllegalArgumentException: java.net.URISyntaxException: Relative path in absolute URI: file:D:/CURRENT_DIRECTORY/spark-warehouse
```

This implementation allows me to proceed, but it appears there's an existing order-of-execution bug to fix:

```
16/10/05 09:09:44 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
16/10/05 09:09:45 WARN SparkContext: Use an existing SparkContext, some configuration may not take effect.
Warehouse dir: C:\Users\USER_NAME\AppData\Local\Temp\spark-32dad1e2-1224-4f11-aa2f-1be5b85dd73b\wharehouse
16/10/05 09:09:45 WARN SparkSession$Builder: Use an existing SparkSession, some configuration may not take effect.
Start test
16/10/05 09:09:48 WARN Utils: Truncated the string representation of a plan since it was too large. This behavior can be adjusted by setting 'spark.debug.maxToStringFields' in SparkEnv.conf.
```

It seems `SharedSparkContext.before_all()` already creates a `SparkContext` and that `DataFrameSuiteBaseLike.sqlBeforeAllTestCases()` tries to create a second one.  However, this particular configuration parameter did persist in the new/merged `SparkContext`. I'm not quite sure how to reorganize the inheritance hierarchy to avoid those warnings, so I figured I'd at least provide the correct Spark 2.0 config value to set.