### PR TITLE
Fixes build error

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,6 @@ resolvers += "Spark Package Main Repo" at "https://dl.bintray.com/spark-packages
 
 addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.5")
 
-//addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.3")


### PR DESCRIPTION
useGpg is provided by sbt-pgp which was commented out. Uncommenting makes the sbt file parse and the tests able to run.