### PR TITLE
Add support for N-level custom ColumnGenerators with StructTypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,5 @@ In surefire make sure that forkCount is set to 1 and reuseForks is true.
 Much of this code is a stripped down version of the test suite bases that are in Apache Spark but are not accessible. Other parts are also inspired by ssbase (scalacheck generators for Spark).
 
 Other parts of this are implemented on top of the test suite bases to make your life even easier.
+
+# [Release Notes](RELEASE_NOTES.md)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,5 @@
+#0.6
+ - Added support for specifying custom generators for fields nested in `StructTypes`
+   - Renamed `ColumnGenerator` to `Column`
+   - Changed `ColumnGenerator` to the base class of column generators
+   - Added `ColumnList` to specify custom generators for a list of columns

--- a/src/main/1.3/scala/com/holdenkarau/spark/testing/DataframeGenerator.scala
+++ b/src/main/1.3/scala/com/holdenkarau/spark/testing/DataframeGenerator.scala
@@ -75,7 +75,7 @@ object DataframeGenerator {
       generator match {
         case gen: ColumnGenerator => (gen.columnName -> gen)
         case list: ColumnGeneratorList => (list.columnName -> list)
-        case _ => throw new ClassCastException
+        case _ => throw new UnsupportedOperationException(s"Type: Only ColumnGenerator and ColumnGeneratorList are supported types")
       }
     ).toMap
     (0 until fields.length).toList.map(index => {
@@ -89,7 +89,7 @@ object DataframeGenerator {
     })
   }
 
-  private def getGenerator(dataType: DataType, generators: Seq[ColumnGenerator] = Seq()): Gen[Any] = {
+  private def getGenerator(dataType: DataType, generators: Seq[Any] = Seq()): Gen[Any] = {
     dataType match {
       case ByteType => Arbitrary.arbitrary[Byte]
       case ShortType => Arbitrary.arbitrary[Short]
@@ -127,6 +127,6 @@ class ColumnGenerator(val columnName: String, generator: => Gen[Any]) extends ja
   lazy val gen = generator
 }
 
-class ColumnGeneratorList(val columnName: String, generators: => Seq[ColumnGenerator]) extends java.io.Serializable {
+class ColumnGeneratorList(val columnName: String, generators: => Seq[Any]) extends java.io.Serializable {
   lazy val gen = generators
 }

--- a/src/test/1.3/scala/com/holdenkarau/spark/testing/SampleScalaCheckTest.scala
+++ b/src/test/1.3/scala/com/holdenkarau/spark/testing/SampleScalaCheckTest.scala
@@ -95,7 +95,7 @@ class SampleScalaCheckTest extends FunSuite with SharedSparkContext with RDDComp
   test("test custom columns generators") {
     val schema = StructType(List(StructField("name", StringType), StructField("age", IntegerType)))
     val sqlContext = new SQLContext(sc)
-    val ageGenerator = new ColumnGenerator("age", Gen.choose(10, 100))
+    val ageGenerator = new Column("age", Gen.choose(10, 100))
     val dataframeGen = DataframeGenerator.arbitraryDataFrameWithCustomFields(sqlContext, schema)(ageGenerator)
 
     val property =
@@ -109,8 +109,8 @@ class SampleScalaCheckTest extends FunSuite with SharedSparkContext with RDDComp
   test("test multiple columns generators") {
     val schema = StructType(List(StructField("name", StringType), StructField("age", IntegerType)))
     val sqlContext = new SQLContext(sc)
-    val nameGenerator = new ColumnGenerator("name", Gen.oneOf("Holden", "Hanafy")) // name should be on of those
-    val ageGenerator = new ColumnGenerator("age", Gen.choose(10, 100))
+    val nameGenerator = new Column("name", Gen.oneOf("Holden", "Hanafy")) // name should be on of those
+    val ageGenerator = new Column("age", Gen.choose(10, 100))
     val dataframeGen = DataframeGenerator.arbitraryDataFrameWithCustomFields(sqlContext, schema)(nameGenerator, ageGenerator)
 
     val property =
@@ -134,10 +134,10 @@ class SampleScalaCheckTest extends FunSuite with SharedSparkContext with RDDComp
       )))
     ))
     val sqlContext = new SQLContext(sc)
-    val userGenerator = new ColumnGeneratorList("user", Seq(
-      new ColumnGenerator("name", Gen.oneOf("Holden", "Hanafy")), // name should be on of those
-      new ColumnGenerator("age", Gen.choose(10, 100)),
-      new ColumnGeneratorList("address", Seq(new ColumnGenerator("zip_code", Gen.choose(100, 200))))
+    val userGenerator = new ColumnList("user", Seq(
+      new Column("name", Gen.oneOf("Holden", "Hanafy")), // name should be on of those
+      new Column("age", Gen.choose(10, 100)),
+      new ColumnList("address", Seq(new Column("zip_code", Gen.choose(100, 200))))
     ))
     val dataframeGen = DataframeGenerator.arbitraryDataFrameWithCustomFields(sqlContext, schema)(userGenerator)
 
@@ -150,14 +150,14 @@ class SampleScalaCheckTest extends FunSuite with SharedSparkContext with RDDComp
     check(property)
   }
 
-  test("assert invalid ColumnGeneratorList does not compile") {
+  test("assert invalid ColumnList does not compile") {
     val schema = StructType(List(
       StructField("user", StructType(List(
         StructField("name", StringType),
         StructField("age", IntegerType)
       )))
     ))
-    assertTypeError("""val userGenerator = new ColumnGeneratorList("user", Seq("list", "of", "an", "unsupported", "type"))""")
+    assertTypeError("""val userGenerator = new ColumnList("user", Seq("list", "of", "an", "unsupported", "type"))""")
   }
 
   test("generate rdd of specific size") {

--- a/src/test/1.3/scala/com/holdenkarau/spark/testing/SampleScalaCheckTest.scala
+++ b/src/test/1.3/scala/com/holdenkarau/spark/testing/SampleScalaCheckTest.scala
@@ -150,6 +150,20 @@ class SampleScalaCheckTest extends FunSuite with SharedSparkContext with RDDComp
     check(property)
   }
 
+  test("assert invalid ColumnGeneratorList throws an Exception") {
+    val schema = StructType(List(
+      StructField("user", StructType(List(
+        StructField("name", StringType),
+        StructField("age", IntegerType)
+      )))
+    ))
+    val userGenerator = new ColumnGeneratorList("user", Seq("list", "of", "an", "unsupported", "type"))
+
+    assertThrows[UnsupportedOperationException] {
+      val rowGen = DataframeGenerator.getRowGenerator(schema, List(userGenerator))
+    }
+  }
+
   test("generate rdd of specific size") {
     implicit val generatorDrivenConfig =
       PropertyCheckConfig(minSize = 10, maxSize = 20)

--- a/src/test/1.3/scala/com/holdenkarau/spark/testing/SampleScalaCheckTest.scala
+++ b/src/test/1.3/scala/com/holdenkarau/spark/testing/SampleScalaCheckTest.scala
@@ -150,18 +150,14 @@ class SampleScalaCheckTest extends FunSuite with SharedSparkContext with RDDComp
     check(property)
   }
 
-  test("assert invalid ColumnGeneratorList throws an Exception") {
+  test("assert invalid ColumnGeneratorList does not compile") {
     val schema = StructType(List(
       StructField("user", StructType(List(
         StructField("name", StringType),
         StructField("age", IntegerType)
       )))
     ))
-    val userGenerator = new ColumnGeneratorList("user", Seq("list", "of", "an", "unsupported", "type"))
-
-    assertThrows[UnsupportedOperationException] {
-      val rowGen = DataframeGenerator.getRowGenerator(schema, List(userGenerator))
-    }
+    assertTypeError("""val userGenerator = new ColumnGeneratorList("user", Seq("list", "of", "an", "unsupported", "type"))""")
   }
 
   test("generate rdd of specific size") {

--- a/src/test/1.6/scala/com/holdenkarau/spark/testing/PrettifyTest.scala
+++ b/src/test/1.6/scala/com/holdenkarau/spark/testing/PrettifyTest.scala
@@ -15,8 +15,8 @@ class PrettifyTest extends FunSuite with SharedSparkContext with Checkers with P
   test("pretty output of DataFrame's check") {
     val schema = StructType(List(StructField("name", StringType), StructField("age", IntegerType)))
     val sqlContext = new SQLContext(sc)
-    val nameGenerator = new ColumnGenerator("name", Gen.const("Holden Hanafy"))
-    val ageGenerator = new ColumnGenerator("age", Gen.const(20))
+    val nameGenerator = new Column("name", Gen.const("Holden Hanafy"))
+    val ageGenerator = new Column("age", Gen.const(20))
 
     val dataframeGen = DataframeGenerator.arbitraryDataFrameWithCustomFields(sqlContext, schema)(nameGenerator, ageGenerator)
 


### PR DESCRIPTION
This PR adds support for N-level deep custom ColumnGenerators which are StructTypes.  This allows users to specify generators for fields in StructTypes, which is quite useful for generating complex data types to test.

The changes are summarized here:
  - Added a new type `ColumnGeneratorList`
  - Changed the type of `userGenerators` to be `Any*`, from `ColumnGenerator*`
  - Change private signatures to match the above
  - Assert at runtime that the types of the `userGenerators` belong to `ColumnGenerator` or `ColumnGeneratorList`, otherwise throw an `UnsupportedOperationException`
  - Added a test for `ColumnGeneratorList`

Comparing the difference between no generators specified for a `StructType` column and having generators specified via a `ColumnGeneratorList`, I have not noticed a performance difference.  However, my testing has not been exhaustive.
