### PR TITLE
Add support for generating the Spark ML UDTs.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -85,6 +85,7 @@ unmanagedSourceDirectories in Compile  := {
 
 unmanagedSourceDirectories in Test  := {
   if (sparkVersion.value >= "2.0.0") Seq(
+    (sourceDirectory in Test)(_ / "2.0/scala"),
     (sourceDirectory in Test)(_ / "1.6/scala"), (sourceDirectory in Test)(_ / "1.6/java"),
     (sourceDirectory in Test)(_ / "1.4/scala"),
     (sourceDirectory in Test)(_ / "1.3/scala"), (sourceDirectory in Test)(_ / "1.3/java")

--- a/src/main/1.3/scala/com/holdenkarau/spark/testing/DataframeGenerator.scala
+++ b/src/main/1.3/scala/com/holdenkarau/spark/testing/DataframeGenerator.scala
@@ -115,6 +115,7 @@ object DataframeGenerator {
         return Gen.mapOf(keyValueGenerator)
       }
       case row: StructType => return getRowGenerator(row, generators)
+      case MLUserDefinedType(generator) => generator
       case _ => throw new UnsupportedOperationException(s"Type: $dataType not supported")
     }
   }

--- a/src/main/2.0/scala/com/holdenkarau/spark/testing/MLUserDefinedType.scala
+++ b/src/main/2.0/scala/com/holdenkarau/spark/testing/MLUserDefinedType.scala
@@ -1,0 +1,33 @@
+package com.holdenkarau.spark.testing
+
+import org.apache.spark.sql.types.DataType
+import org.apache.spark.ml.linalg.SQLDataTypes.{MatrixType, VectorType}
+import org.apache.spark.ml.linalg.{DenseMatrix, Vectors}
+import org.scalacheck.{Arbitrary, Gen}
+
+/**
+ * Extractor that matches the UDTs exposed by Spark ML.
+ */
+object MLUserDefinedType {
+  def unapply(dataType: DataType): Option[Gen[Any]] =
+    dataType match {
+      case MatrixType => {
+        val dense = for {
+          rows <- Gen.choose(0, 20)
+          cols <- Gen.choose(0, 20)
+          values <- Gen.containerOfN[Array, Double](rows * cols, Arbitrary.arbitrary[Double])
+        } yield new DenseMatrix(rows, cols, values)
+        val sparse = dense.map(_.toSparse)
+        Some(Gen.oneOf(dense, sparse))
+      }
+      case VectorType => {
+        val dense = Arbitrary.arbitrary[Array[Double]].map(Vectors.dense)
+        val sparse = for {
+          indices <- Gen.nonEmptyContainerOf[Set, Int](Gen.choose(0, Int.MaxValue - 1))
+          values <- Gen.listOfN(indices.size, Arbitrary.arbitrary[Double])
+        } yield Vectors.sparse(indices.max + 1, indices.toSeq.zip(values))
+        Some(Gen.oneOf(dense, sparse))
+      }
+      case _ => None
+    }
+}

--- a/src/main/pre-2.0/scala/com/holdenkarau/spark/testing/MLUserDefinedType.scala
+++ b/src/main/pre-2.0/scala/com/holdenkarau/spark/testing/MLUserDefinedType.scala
@@ -1,0 +1,12 @@
+package com.holdenkarau.spark.testing
+
+import org.apache.spark.sql.types.DataType
+import org.scalacheck.Gen
+
+/**
+  * Compatibility shim for the extractor that matches the UDTs exposed by Spark ML.
+  */
+object MLUserDefinedType {
+  def unapply(dataType: DataType): Option[Gen[Any]] =
+    None
+}

--- a/src/test/2.0/scala/com/holdenkarau/spark/testing/MLScalaCheckTest.scala
+++ b/src/test/2.0/scala/com/holdenkarau/spark/testing/MLScalaCheckTest.scala
@@ -1,0 +1,40 @@
+package com.holdenkarau.spark.testing
+
+import org.apache.spark.ml.linalg.SQLDataTypes.{MatrixType, VectorType}
+import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.types.{StructField, StructType}
+import org.scalacheck.Prop.forAll
+import org.scalatest.FunSuite
+import org.scalatest.prop.Checkers
+
+class MLScalaCheckTest extends FunSuite with SharedSparkContext with Checkers {
+  test("vector generation") {
+    val schema = StructType(List(StructField("vector", VectorType)))
+    val sqlContext = new SQLContext(sc)
+    val dataframeGen = DataframeGenerator.arbitraryDataFrame(sqlContext, schema)
+
+    val property =
+      forAll(dataframeGen.arbitrary) {
+        dataframe => {
+          dataframe.schema === schema && dataframe.count >= 0
+        }
+      }
+
+    check(property)
+  }
+
+  test("matrix generation") {
+    val schema = StructType(List(StructField("matrix", MatrixType)))
+    val sqlContext = new SQLContext(sc)
+    val dataframeGen = DataframeGenerator.arbitraryDataFrame(sqlContext, schema)
+
+    val property =
+      forAll(dataframeGen.arbitrary) {
+        dataframe => {
+          dataframe.schema === schema && dataframe.count >= 0
+        }
+      }
+
+    check(property)
+  }
+}


### PR DESCRIPTION
Spark ML has a couple of UDTs for vectors and matrices; this PR adds support for generating `DataFrame` instances for schemas containing them.

I've done this by adding an extractor that's used in the `match` statement of `DataframeGenerator.getGenerator`, because this seemed like a relatively unobtrusive way of dealing with these types only being available in Spark ≥ 2.0, but if you'd like this done in a different way I'm happy to change it.