### PR TITLE
Adding localhost as driver host fixes a problem executing tests offline on Mac OS, without needing to set environment variables or add configuration options elsewhere

### DIFF
--- a/src/main/1.3/scala/com/holdenkarau/spark/testing/SparkContextProvider.scala
+++ b/src/main/1.3/scala/com/holdenkarau/spark/testing/SparkContextProvider.scala
@@ -29,7 +29,8 @@ trait SparkContextProvider {
       setMaster("local[*]").
       setAppName("test").
       set("spark.ui.enabled", "false").
-      set("spark.app.id", appID)
+      set("spark.app.id", appID).
+      set("spark.driver.host", "localhost")
   }
 
 

--- a/src/main/1.3/scala/com/holdenkarau/spark/testing/StreamingSuiteCommon.scala
+++ b/src/main/1.3/scala/com/holdenkarau/spark/testing/StreamingSuiteCommon.scala
@@ -99,6 +99,7 @@ private[holdenkarau] trait StreamingSuiteCommon extends Logging with SparkContex
   override def conf = new SparkConf()
     .setMaster(master)
     .setAppName(framework)
+    .set("spark.driver.host", "localhost")
     .set("spark.streaming.clock", "org.apache.spark.streaming.util.TestManualClock")
 
   // Timeout for use in ScalaTest `eventually` blocks


### PR DESCRIPTION
2 tests failed locally on master, online (I guess some misconfiguration I have on my development environment):

```
[error] 	com.holdenkarau.spark.testing.YARNClusterTest
[error] 	com.holdenkarau.spark.testing.SampleMiniClusterTest
```

Offline on master (on MacOS, that is), 19 tests failed

The same two tests failed, online and offline on this branch (also on MacOS of course). 

I'm not sure this is the best/adequate way of fixing this instead of setting an environment variable or passing some extra configuration. The good part about doing it in the library is that it then works "out of the box", offline, no matter what without extra configuration. 