### PR TITLE
Better log when asserting Schema

### DIFF
--- a/src/main/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteBase.scala
+++ b/src/main/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteBase.scala
@@ -188,7 +188,7 @@ object DataFrameSuiteBase {
       s"StructType(${fieldStrings.mkString(",")}"
     }
     val expectedString = s"Expected Schema: ${structFieldsToString(expected.fields)}"
-    val resultString = s"result Schema: ${structFieldsToString(result.fields)}"
+    val resultString = s"Result Schema: ${structFieldsToString(result.fields)}"
 
     s"$expectedString does not match $resultString"
   }

--- a/src/main/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteBase.scala
+++ b/src/main/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteBase.scala
@@ -30,9 +30,9 @@ import org.scalatest.Suite
 import scala.math.abs
 
 /**
-  * :: Experimental ::
-  * Base class for testing Spark DataFrames.
-  */
+ * :: Experimental ::
+ * Base class for testing Spark DataFrames.
+ */
 trait DataFrameSuiteBase
     extends TestSuite
     with SharedSparkContext
@@ -53,20 +53,24 @@ trait DataFrameSuiteBaseLike
     with TestSuiteLike
     with Serializable {
   val maxUnequalRowsToShow = 10
-  @transient lazy val spark: SparkSession = SparkSessionProvider._sparkSession
-  @transient lazy val sqlContext: SQLContext = SparkSessionProvider.sqlContext
+  @transient lazy val spark: SparkSession =
+    SparkSessionProvider._sparkSession
+  @transient lazy val sqlContext: SQLContext =
+    SparkSessionProvider.sqlContext
 
   protected implicit def impSqlContext: SQLContext = sqlContext
 
   def sqlBeforeAllTestCases() {
 
     /**
-      * Constructs a configuration for hive, where the metastore is located in a
-      * temp directory.
-      */
+     * Constructs a configuration for hive, where the metastore is located in a
+     * temp directory.
+     */
     val tempDir = Utils.createTempDir()
-    val localMetastorePath = new File(tempDir, "metastore").getCanonicalPath
-    val localWarehousePath = new File(tempDir, "wharehouse").getCanonicalPath
+    val localMetastorePath =
+      new File(tempDir, "metastore").getCanonicalPath
+    val localWarehousePath =
+      new File(tempDir, "wharehouse").getCanonicalPath
 
     def newBuilder() = {
       val builder = SparkSession.builder()
@@ -105,11 +109,11 @@ trait DataFrameSuiteBaseLike
   }
 
   /**
-    * Compares if two [[DataFrame]]s are equal, checks the schema and then if that
-    * matches checks if the rows are equal.
-    */
+   * Compares if two [[DataFrame]]s are equal, checks the schema and then if that
+   * matches checks if the rows are equal.
+   */
   def assertDataFrameEquals(expected: DataFrame, result: DataFrame) {
-    schemaEquals(expected, result)
+    assertSchemaEquals(expected, result)
     try {
       expected.rdd.cache
       result.rdd.cache
@@ -130,16 +134,15 @@ trait DataFrameSuiteBaseLike
     }
   }
 
-  /**
-    * Compares if two [[DataFrame]]s are equal, checks that the schemas are the same.
-    * When comparing inexact fields uses tol.
-    *
-    * @param tol max acceptable tolerance, should be less than 1.
-    */
+  /** Compares if two [[DataFrame]]s are equal, checks that the schemas are the same.
+   * When comparing inexact fields uses tol.
+   *
+   * @param tol max acceptable tolerance, should be less than 1.
+   */
   def assertDataFrameApproximateEquals(expected: DataFrame,
                                        result: DataFrame,
                                        tol: Double) {
-    schemaEquals(expected, result)
+    assertSchemaEquals(expected, result)
     try {
       expected.rdd.cache
       result.rdd.cache
@@ -161,10 +164,10 @@ trait DataFrameSuiteBaseLike
   }
 
   /**
-    * Zip RDD's with precise indexes. This is used so we can join two DataFrame's
-    * Rows together regardless of if the source is different but still compare
-    * based on the order.
-    */
+   * Zip RDD's with precise indexes. This is used so we can join two DataFrame's
+   * Rows together regardless of if the source is different but still compare
+   * based on the order.
+   */
   private[testing] def zipWithIndex[U](rdd: RDD[U]) = {
     rdd.zipWithIndex().map { case (row, idx) => (idx, row) }
   }
@@ -173,7 +176,7 @@ trait DataFrameSuiteBaseLike
     DataFrameSuiteBase.approxEquals(r1, r2, tol)
   }
 
-  def schemaEquals(expected: DataFrame, result: DataFrame): Unit = {
+  def assertSchemaEquals(expected: DataFrame, result: DataFrame): Unit = {
     val expectedSchema = expected.schema
     val resultSchema = result.schema
     val errorString = schemaErrorMessage(expectedSchema, resultSchema)
@@ -183,7 +186,8 @@ trait DataFrameSuiteBaseLike
 
 object DataFrameSuiteBase {
 
-  def schemaErrorMessage(expected: StructType, result: StructType): String = {
+  def schemaErrorMessage(expected: StructType,
+                         result: StructType): String = {
     def structFieldsToString(fields: Array[StructField]): String = {
       val fieldStrings = fields.map {
         case StructField(name, dataType, nullable, metadata) =>
@@ -193,9 +197,11 @@ object DataFrameSuiteBase {
     }
 
     s"""
-       |Expected Schema: ${structFieldsToString(expected.fields)}
+       |Expected Schema:
+       |${structFieldsToString(expected.fields)}
        |does not match
-       |Result Schema: ${structFieldsToString(result.fields)}
+       |Result Schema:
+       |${structFieldsToString(result.fields)}
        |""".stripMargin
   }
 
@@ -216,7 +222,9 @@ object DataFrameSuiteBase {
           val o2 = r2.get(idx)
           o1 match {
             case b1: Array[Byte] =>
-              if (!java.util.Arrays.equals(b1, o2.asInstanceOf[Array[Byte]])) {
+              if (!java.util.Arrays.equals(
+                    b1,
+                    o2.asInstanceOf[Array[Byte]])) {
                 return false
               }
 

--- a/src/main/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteBase.scala
+++ b/src/main/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteBase.scala
@@ -20,16 +20,14 @@ package com.holdenkarau.spark.testing
 import java.io.File
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase.schemaErrorMessage
+import org.apache.hadoop.hive.conf.HiveConf
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql._
+import org.apache.spark.sql.types.{StructField, StructType}
 import org.scalatest.Suite
 
 import scala.math.abs
-import scala.collection.mutable.HashMap
-import org.apache.spark.rdd.RDD
-import org.apache.spark.sql._
-import org.apache.spark.sql.hive._
-import org.apache.hadoop.hive.conf.HiveConf
-import org.apache.hadoop.hive.conf.HiveConf.ConfVars
-import org.apache.spark.sql.types.{StructField, StructType}
 
 /**
  * :: Experimental ::
@@ -168,7 +166,7 @@ trait DataFrameSuiteBaseLike extends SparkContextProvider
     DataFrameSuiteBase.approxEquals(r1, r2, tol)
   }
 
-  def schemaEquals(expected: DataFrame, result: DataFrame) = {
+  def schemaEquals(expected: DataFrame, result: DataFrame): Unit = {
     val expectedSchema = expected.schema
     val resultSchema = result.schema
     val errorString = schemaErrorMessage(expectedSchema, resultSchema)
@@ -181,16 +179,17 @@ object DataFrameSuiteBase {
   def schemaErrorMessage(expected: StructType, result: StructType): String = {
     def structFieldsToString(fields: Array[StructField]): String = {
       val fieldStrings = fields.map {
-        case StructField(name, dataType, nullable, metadata) => {
+        case StructField(name, dataType, nullable, metadata) =>
           s"StructField($name,$dataType,$nullable,$metadata)"
-        }
       }
       s"StructType(${fieldStrings.mkString(",")}"
     }
-    val expectedString = s"Expected Schema: ${structFieldsToString(expected.fields)}"
-    val resultString = s"Result Schema: ${structFieldsToString(result.fields)}"
 
-    s"$expectedString does not match $resultString"
+    s"""
+      |Expected Schema: ${structFieldsToString(expected.fields)}
+      |does not match
+      |Result Schema: ${structFieldsToString(result.fields)}
+    """.stripMargin
   }
 
   /** Approximate equality, based on equals from [[Row]] */

--- a/src/main/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteBase.scala
+++ b/src/main/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteBase.scala
@@ -187,7 +187,10 @@ object DataFrameSuiteBase {
       }
       s"StructType(${fieldStrings.mkString(",")}"
     }
-    s"Expected Schema: ${structFieldsToString(expected.fields)} does not match result Schema: ${structFieldsToString(result.fields)}"
+    val expectedString = s"Expected Schema: ${structFieldsToString(expected.fields)}"
+    val resultString = s"result Schema: ${structFieldsToString(result.fields)}"
+
+    s"$expectedString does not match $resultString"
   }
 
   /** Approximate equality, based on equals from [[Row]] */

--- a/src/test/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteBaseTest.scala
+++ b/src/test/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteBaseTest.scala
@@ -8,16 +8,13 @@ import org.scalatest.prop.Checkers
 
 import scala.collection.JavaConversions._
 
-
 case class PersonAge(name: String, age: Int)
 
 class DataFrameSuiteBaseTest
-extends FunSuite
-with SharedSparkContext
-with Checkers
-with DataFrameSuiteBase {
-
-  import sqlContext.implicits._
+  extends FunSuite
+    with SharedSparkContext
+    with Checkers
+    with DataFrameSuiteBase {
 
   test("testSchemaErrorMessage") {
     val metadataOne =
@@ -30,11 +27,13 @@ with DataFrameSuiteBase {
     val resultField = Seq(StructField("colA", IntegerType, false, metadataTwo))
     val resultSchema = StructType(resultField)
 
-    val errorString = """
-      |Expected Schema: StructType(StructField(colA,IntegerType,false,{"someKey":false})
-      |does not match
-      |Result Schema: StructType(StructField(colA,IntegerType,false,{"someKey":true})
-    """.stripMargin
+    //noinspection ScalaStyle
+    val errorString =
+      """
+        |Expected Schema: StructType(StructField(colA,IntegerType,false,{"someKey":false})
+        |does not match
+        |Result Schema: StructType(StructField(colA,IntegerType,false,{"someKey":true})
+        |""".stripMargin
 
     val resultErrorString =
       schemaErrorMessage(expectedSchema, resultSchema)
@@ -44,6 +43,7 @@ with DataFrameSuiteBase {
 
   test("assertSchemaEquals passes when schema are equal") {
 
+    import sqlContext.implicits._
     val data = List(PersonAge("Alice", 12), PersonAge("Bob", 45))
     val expectedDf = sc.parallelize(data).toDF
     val resultDf = sc.parallelize(data).toDF
@@ -72,7 +72,7 @@ with DataFrameSuiteBase {
       " did not equal " +
       "StructType(StructField(name,StringType,true))"
     val customErrorString = schemaErrorMessage(expectedSchema, resultSchema)
-    val errorString =  assertErrorString + customErrorString
+    val errorString = assertErrorString + customErrorString
     assert(failedException.getMessage() == errorString)
   }
 }

--- a/src/test/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteBaseTest.scala
+++ b/src/test/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteBaseTest.scala
@@ -1,0 +1,20 @@
+package com.holdenkarau.spark.testing
+
+import org.apache.spark.sql.types.{IntegerType, MetadataBuilder, StructField, StructType}
+import org.scalatest.FunSuite
+import org.scalatest.prop.Checkers
+
+class DataFrameSuiteBaseTest extends FunSuite with SharedSparkContext with Checkers {
+
+  test("testSchemaErrorMessage") {
+    val expectedSchema = StructType(Seq(StructField("colA", IntegerType, false, new MetadataBuilder().putBoolean("someKey", false).build())))
+
+    val resultSchema = StructType(Seq(StructField("colA", IntegerType, false, new MetadataBuilder().putBoolean("someKey", true).build())))
+
+    val expectedErrorString = "Expected Schema: StructType(StructField(colA,IntegerType,false,{\"someKey\":false}) does not match result Schema: StructType(StructField(colA,IntegerType,false,{\"someKey\":true})"
+
+    val resultErrorString = DataFrameSuiteBase.schemaErrorMessage(expectedSchema, resultSchema)
+
+    assert(expectedErrorString.equals(resultErrorString))
+  }
+}

--- a/src/test/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteBaseTest.scala
+++ b/src/test/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteBaseTest.scala
@@ -1,19 +1,36 @@
 package com.holdenkarau.spark.testing
 
-import org.apache.spark.sql.types.{IntegerType, MetadataBuilder, StructField, StructType}
+import org.apache.spark.sql.types.{
+  IntegerType,
+  MetadataBuilder,
+  StructField,
+  StructType
+}
 import org.scalatest.FunSuite
 import org.scalatest.prop.Checkers
 
-class DataFrameSuiteBaseTest extends FunSuite with SharedSparkContext with Checkers {
+class DataFrameSuiteBaseTest
+    extends FunSuite
+    with SharedSparkContext
+    with Checkers {
 
   test("testSchemaErrorMessage") {
-    val expectedSchema = StructType(Seq(StructField("colA", IntegerType, false, new MetadataBuilder().putBoolean("someKey", false).build())))
+    val metadataOne =
+      new MetadataBuilder().putBoolean("someKey", false).build()
+    val expectedField =
+      Seq(StructField("colA", IntegerType, false, metadataOne))
+    val expectedSchema = StructType(expectedField)
 
-    val resultSchema = StructType(Seq(StructField("colA", IntegerType, false, new MetadataBuilder().putBoolean("someKey", true).build())))
+    val metadataTwo = new MetadataBuilder().putBoolean("someKey", true).build()
+    val resultField = Seq(StructField("colA", IntegerType, false, metadataTwo))
+    val resultSchema = StructType(resultField)
 
-    val expectedErrorString = "Expected Schema: StructType(StructField(colA,IntegerType,false,{\"someKey\":false}) does not match result Schema: StructType(StructField(colA,IntegerType,false,{\"someKey\":true})"
+    //noinspection ScalaStyle
+    val expectedErrorString =
+      "Expected Schema: StructType(StructField(colA,IntegerType,false,{\"someKey\":false}) does not match result Schema: StructType(StructField(colA,IntegerType,false,{\"someKey\":true})"
 
-    val resultErrorString = DataFrameSuiteBase.schemaErrorMessage(expectedSchema, resultSchema)
+    val resultErrorString =
+      DataFrameSuiteBase.schemaErrorMessage(expectedSchema, resultSchema)
 
     assert(expectedErrorString.equals(resultErrorString))
   }

--- a/src/test/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteBaseTest.scala
+++ b/src/test/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteBaseTest.scala
@@ -25,13 +25,19 @@ class DataFrameSuiteBaseTest
     val resultField = Seq(StructField("colA", IntegerType, false, metadataTwo))
     val resultSchema = StructType(resultField)
 
-    //noinspection ScalaStyle
-    val expectedErrorString =
-      "Expected Schema: StructType(StructField(colA,IntegerType,false,{\"someKey\":false}) does not match result Schema: StructType(StructField(colA,IntegerType,false,{\"someKey\":true})"
+    val expectedSchemaString = "Expected Schema: " +
+      "StructType(StructField(colA,IntegerType,false,{\"someKey\":false})"
+
+    val resultSchemaString = "Result Schema: " +
+      "StructType(StructField(colA,IntegerType,false,{\"someKey\":true})"
+
+    val errorString = expectedSchemaString +
+      " does not match " +
+      resultSchemaString
 
     val resultErrorString =
       DataFrameSuiteBase.schemaErrorMessage(expectedSchema, resultSchema)
 
-    assert(expectedErrorString.equals(resultErrorString))
+    assert(errorString.equals(resultErrorString))
   }
 }

--- a/src/test/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteSchemaTest.scala
+++ b/src/test/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteSchemaTest.scala
@@ -10,7 +10,7 @@ import scala.collection.JavaConversions._
 
 case class PersonAge(name: String, age: Int)
 
-class DataFrameSuiteBaseTest
+class DataFrameSuiteSchemaTest
   extends FunSuite
     with SharedSparkContext
     with Checkers
@@ -27,12 +27,13 @@ class DataFrameSuiteBaseTest
     val resultField = Seq(StructField("colA", IntegerType, false, metadataTwo))
     val resultSchema = StructType(resultField)
 
-    //noinspection ScalaStyle
     val errorString =
       """
-        |Expected Schema: StructType(StructField(colA,IntegerType,false,{"someKey":false})
+        |Expected Schema:
+        |StructType(StructField(colA,IntegerType,false,{"someKey":false})
         |does not match
-        |Result Schema: StructType(StructField(colA,IntegerType,false,{"someKey":true})
+        |Result Schema:
+        |StructType(StructField(colA,IntegerType,false,{"someKey":true})
         |""".stripMargin
 
     val resultErrorString =
@@ -65,7 +66,7 @@ class DataFrameSuiteBaseTest
     val resultDf = sqlContext.createDataFrame(data, resultSchema)
     val failedException =
       intercept[org.scalatest.exceptions.TestFailedException] {
-        schemaEquals(expectedDf, resultDf)
+        assertSchemaEquals(expectedDf, resultDf)
       }
 
     val assertErrorString = "StructType(StructField(name,StringType,true))" +


### PR DESCRIPTION
This PR address #179 . 

```scala
def assert[U](message: String, expected: U, actual: U) 
```
has been used to log a better error message when there is a schema mismatch.

Error message is a glorified version of StructField toString which now includes Metadata also. 