### PR TITLE
Provide support for testing InputDStreams

### DIFF
--- a/src/main/2.0/scala/com/holdenkarau/spark/testing/receiver/InputStreamSuiteBase.scala
+++ b/src/main/2.0/scala/com/holdenkarau/spark/testing/receiver/InputStreamSuiteBase.scala
@@ -6,23 +6,29 @@ import org.scalatest.FunSuite
 
 
 /**
-  * Supports unit testing of [[org.apache.spark.streaming.dstream.InputDStream]]s  wherein each test will typically
+  * Supports unit testing of [[org.apache.spark.streaming.dstream.InputDStream]]s
+  * wherein each test will typically
   *
   *   - perform some set up of test fixtures
   *
-  *   - create an instance of an [[InputStreamTestingContext]] and invoke the run() method of that instance.
+  *   - create an instance of an [[InputStreamTestingContext]] and invoke the
+  *   run() method of that instance.
   *
-  * The parent trait --  [[StreamingSuiteBase]] -- serves to provide the [[org.apache.spark.SparkContext]] from which
-  * a [[org.apache.spark.streaming.StreamingContext]] will be created and stopped for each individual test. The
-  * [[org.apache.spark.SparkContext]] is re-used for each test in the suite.
+  * The parent trait --  [[StreamingSuiteBase]] -- serves to provide the
+  * [[org.apache.spark.SparkContext]] from which
+  * a [[org.apache.spark.streaming.StreamingContext]] will be created and stopped
+  * for each individual test. The [[org.apache.spark.SparkContext]]
+  * is re-used for each test in the suite.
   */
 trait InputStreamSuiteBase extends FunSuite with StreamingSuiteBase {
   /**
-    *  Use system clock rather than TestManualClock because receivers will never run otherwise.
+    *  Use system clock rather than TestManualClock, otherwise receivers never run.
     */
   override def conf: SparkConf = {
     val confToTweak = super.conf
-    confToTweak.set("spark.streaming.clock", "org.apache.spark.streaming.util.SystemClock")
+    confToTweak.set(
+      "spark.streaming.clock",
+      "org.apache.spark.streaming.util.SystemClock")
     confToTweak
   }
 }

--- a/src/main/2.0/scala/com/holdenkarau/spark/testing/receiver/InputStreamSuiteBase.scala
+++ b/src/main/2.0/scala/com/holdenkarau/spark/testing/receiver/InputStreamSuiteBase.scala
@@ -1,0 +1,28 @@
+package com.holdenkarau.spark.testing.receiver
+
+import com.holdenkarau.spark.testing.StreamingSuiteBase
+import org.apache.spark.SparkConf
+import org.scalatest.FunSuite
+
+
+/**
+  * Supports unit testing of [[org.apache.spark.streaming.dstream.InputDStream]]s  wherein each test will typically
+  *
+  *   - perform some set up of test fixtures
+  *
+  *   - create an instance of an [[InputStreamTestingContext]] and invoke the run() method of that instance.
+  *
+  * The parent trait --  [[StreamingSuiteBase]] -- serves to provide the [[org.apache.spark.SparkContext]] from which
+  * a [[org.apache.spark.streaming.StreamingContext]] will be created and stopped for each individual test. The
+  * [[org.apache.spark.SparkContext]] is re-used for each test in the suite.
+  */
+trait InputStreamSuiteBase extends FunSuite with StreamingSuiteBase {
+  /**
+    *  Use system clock rather than TestManualClock because receivers will never run otherwise.
+    */
+  override def conf: SparkConf = {
+    val confToTweak = super.conf
+    confToTweak.set("spark.streaming.clock", "org.apache.spark.streaming.util.SystemClock")
+    confToTweak
+  }
+}

--- a/src/main/2.0/scala/com/holdenkarau/spark/testing/receiver/InputStreamTestingContext.scala
+++ b/src/main/2.0/scala/com/holdenkarau/spark/testing/receiver/InputStreamTestingContext.scala
@@ -1,0 +1,65 @@
+package com.holdenkarau.spark.testing.receiver
+
+import org.apache.spark.SparkContext
+import org.apache.spark.streaming.dstream.DStream
+import org.apache.spark.streaming.{Duration, Seconds, StreamingContext}
+
+/**
+  * Sequences the execution of user-provided code that comprises one individual test of an
+  * [[InputStreamSuiteBase]] test suite. Each individual test will typically instantiate one instance of this class.
+  *
+  * @param sparkContext        - a  [[com.holdenkarau.spark.testing.SharedSparkContext]] instance, provided by
+  *                            [[com.holdenkarau.spark.testing.StreamingSuiteBase]], which will be used to create
+  *                            an instance of  a [[org.apache.spark.streaming.StreamingContext]] that will be used
+  *                            for a run of one individual test.
+  *
+  * @param dStreamCreationFunc - a user-provided code block that uses  the StreamingContext provided by this class
+  *                            to generate a [[org.apache.spark.streaming.dstream.DStream]].
+  *
+  * @param testDataGenerationFunc - a user-provided code block that generates test data to be consumed by the
+  *                               [[org.apache.spark.streaming.dstream.InputDStream]] under test.
+  *
+  * @param pauseDuration          - the amount of time to wait before kicking off [[testDataGenerationFunc]].
+  *
+  * @param expectedResult         - the number of results that we expect to find in the DStream produced
+  *                               by [[InputStreamTestingContext.dStreamCreationFunc]]
+  *
+  * @param verboseOutput          - indicates whether internal INFO level logging info from Spark should appear or not
+  *
+  * @param streamingContextCreatorFunc - optional custom method to generate a [[StreamingContext]]
+  *                                    from a [[SparkContext]]
+  *
+  * @param batchDuration        - duration of batch  cycle for streaming context
+  *
+  * @param awaitResultsTimeout - the amount of time to wait for user-provided Dstream generation code to yield results.
+  *
+  * @tparam T - the type of object written into the DStream under test.
+  */
+case class InputStreamTestingContext[T](sparkContext: SparkContext,
+                                        dStreamCreationFunc: (StreamingContext) => DStream[T],
+                                        testDataGenerationFunc: () => Unit,
+                                        pauseDuration: scala.concurrent.duration.Duration,
+                                        expectedResult: List[T],
+                                        verboseOutput: Boolean = false,
+                                        streamingContextCreatorFunc: Option[(SparkContext) => StreamingContext] = None,
+                                        batchDuration : Duration = Seconds(1),
+                                        awaitResultsTimeout : Duration =  Seconds(10)) {
+
+  val ssc: StreamingContext = if (streamingContextCreatorFunc.isDefined) {
+    streamingContextCreatorFunc.get(sparkContext)
+  } else {
+    new StreamingContext(sparkContext, batchDuration )
+  }
+
+  def run(): Unit = {
+    ssc.sparkContext.setLogLevel(if (verboseOutput) "info" else "warn")
+    val verifier =
+      InputStreamVerifier[T](
+        expectedResult.length,
+        scala.concurrent.duration.Duration(s"${awaitResultsTimeout.milliseconds} ms"))
+    verifier.runWithStreamingContext(ssc, dStreamCreationFunc)
+    Thread.sleep(pauseDuration.toMillis) // give the code that creates the DStream time to start up
+    testDataGenerationFunc() // generate test data that codeBlock will convert into a DStream[T]
+    verifier.awaitAndVerifyResults(ssc, expectedResult)
+  }
+}

--- a/src/main/2.0/scala/com/holdenkarau/spark/testing/receiver/InputStreamTestingContext.scala
+++ b/src/main/2.0/scala/com/holdenkarau/spark/testing/receiver/InputStreamTestingContext.scala
@@ -1,54 +1,60 @@
 package com.holdenkarau.spark.testing.receiver
 
+import com.holdenkarau.spark.testing.{SharedSparkContext, StreamingSuiteBase}
 import org.apache.spark.SparkContext
-import org.apache.spark.streaming.dstream.DStream
+import org.apache.spark.streaming.dstream.{DStream, InputDStream}
 import org.apache.spark.streaming.{Duration, Seconds, StreamingContext}
 
 /**
-  * Sequences the execution of user-provided code that comprises one individual test of an
-  * [[InputStreamSuiteBase]] test suite. Each individual test will typically instantiate one instance of this class.
+  * Sequences the execution of user-provided code that comprises one individual
+  * test of an [[InputStreamSuiteBase]] test suite. Each individual test will
+  * typically instantiate one instance of this class.
   *
-  * @param sparkContext        - a  [[com.holdenkarau.spark.testing.SharedSparkContext]] instance, provided by
-  *                            [[com.holdenkarau.spark.testing.StreamingSuiteBase]], which will be used to create
-  *                            an instance of  a [[org.apache.spark.streaming.StreamingContext]] that will be used
-  *                            for a run of one individual test.
-  *
-  * @param dStreamCreationFunc - a user-provided code block that uses  the StreamingContext provided by this class
-  *                            to generate a [[org.apache.spark.streaming.dstream.DStream]].
-  *
-  * @param testDataGenerationFunc - a user-provided code block that generates test data to be consumed by the
-  *                               [[org.apache.spark.streaming.dstream.InputDStream]] under test.
-  *
-  * @param pauseDuration          - the amount of time to wait before kicking off [[testDataGenerationFunc]].
-  *
-  * @param expectedResult         - the number of results that we expect to find in the DStream produced
-  *                               by [[InputStreamTestingContext.dStreamCreationFunc]]
-  *
-  * @param verboseOutput          - indicates whether internal INFO level logging info from Spark should appear or not
-  *
-  * @param streamingContextCreatorFunc - optional custom method to generate a [[StreamingContext]]
-  *                                    from a [[SparkContext]]
-  *
-  * @param batchDuration        - duration of batch  cycle for streaming context
-  *
-  * @param awaitResultsTimeout - the amount of time to wait for user-provided Dstream generation code to yield results.
-  *
+  * @param sparkContext                - a  [[SharedSparkContext]] instance, provided
+  *                                    by [[StreamingSuiteBase]], which will be used
+  *                                    to create an instance of  a
+  *                                    [[StreamingContext]] that will
+  *                                    be used for a run of one individual test.
+  * @param dStreamCreationFunc         - a user-provided code block that uses  the
+  *                                    StreamingContext provided by this class
+  *                                    to generate a [[DStream]].
+  * @param testDataGenerationFunc      - a user-provided code block that generates
+  *                                    test data to be consumed by the
+  *                                    [[InputDStream]] under test.
+  * @param pauseDuration               - the amount of time to wait before kicking
+  *                                    off [[testDataGenerationFunc]].
+  * @param expectedResult              - the number of results that we expect to
+  *                                    find in the DStream produced
+  *                                    by [[dStreamCreationFunc]]
+  * @param verboseOutput               - indicates whether internal INFO level
+  *                                    logging info from Spark should appear or not
+  * @param streamingContextCreatorFunc - optional custom method to generate
+  *                                    a [[StreamingContext]] from
+  *                                    a [[SparkContext]]
+  * @param batchDuration               - duration of batch  cycle for streaming
+  *                                    context
+  * @param awaitTimeout         - the amount of time to wait for
+  *                                    user-provided Dstream generation code to yield
+  *                                    results.
   * @tparam T - the type of object written into the DStream under test.
   */
-case class InputStreamTestingContext[T](sparkContext: SparkContext,
-                                        dStreamCreationFunc: (StreamingContext) => DStream[T],
-                                        testDataGenerationFunc: () => Unit,
-                                        pauseDuration: scala.concurrent.duration.Duration,
-                                        expectedResult: List[T],
-                                        verboseOutput: Boolean = false,
-                                        streamingContextCreatorFunc: Option[(SparkContext) => StreamingContext] = None,
-                                        batchDuration : Duration = Seconds(1),
-                                        awaitResultsTimeout : Duration =  Seconds(10)) {
+case class InputStreamTestingContext[T]
+(
+  sparkContext: SparkContext,
+  dStreamCreationFunc: (StreamingContext) => DStream[T],
+  testDataGenerationFunc: () => Unit,
+  pauseDuration: scala.concurrent.duration.Duration,
+  expectedResult: List[T],
+  verboseOutput: Boolean = false,
+  streamingContextCreatorFunc: Option[(SparkContext) => StreamingContext] = None,
+  batchDuration: Duration = Seconds(1),
+  awaitTimeout: Duration = Seconds(10)
+) {
 
   val ssc: StreamingContext = if (streamingContextCreatorFunc.isDefined) {
     streamingContextCreatorFunc.get(sparkContext)
   } else {
-    new StreamingContext(sparkContext, batchDuration )
+    new StreamingContext(sparkContext, batchDuration)
   }
 
   def run(): Unit = {
@@ -56,10 +62,14 @@ case class InputStreamTestingContext[T](sparkContext: SparkContext,
     val verifier =
       InputStreamVerifier[T](
         expectedResult.length,
-        scala.concurrent.duration.Duration(s"${awaitResultsTimeout.milliseconds} ms"))
+        scala.concurrent.duration.Duration(s"${awaitTimeout.milliseconds} ms"))
     verifier.runWithStreamingContext(ssc, dStreamCreationFunc)
-    Thread.sleep(pauseDuration.toMillis) // give the code that creates the DStream time to start up
-    testDataGenerationFunc() // generate test data that codeBlock will convert into a DStream[T]
+
+    // give the code that creates the DStream time to start up
+    Thread.sleep(pauseDuration.toMillis)
+    // generate test data that codeBlock will convert into a DStream[T]
+    testDataGenerationFunc()
+
     verifier.awaitAndVerifyResults(ssc, expectedResult)
   }
 }

--- a/src/main/2.0/scala/com/holdenkarau/spark/testing/receiver/InputStreamVerifier.scala
+++ b/src/main/2.0/scala/com/holdenkarau/spark/testing/receiver/InputStreamVerifier.scala
@@ -1,0 +1,79 @@
+package com.holdenkarau.spark.testing.receiver
+
+import org.apache.spark.Logging
+import org.apache.spark.streaming.dstream.DStream
+import org.apache.spark.streaming.{Seconds, StreamingContext, StreamingContextState}
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
+
+/**
+  *  Runs user-provided code that  generates a [[org.apache.spark.streaming.dstream.DStream]], after which point
+  *  awaitAndVerifyResults() may be called to block until
+  *  [[com.holdenkarau.spark.testing.receiver.InputStreamVerifier.numExpectedResults]]
+  *  items appear in the directory where results are recorded.
+  *
+  * @param numExpectedResults - the number of individual items that the user-provided Dstream generation code is
+  *                           expected to yield.
+  *
+  * @param awaitResultsTimeout - the amount of time to wait for user-provided Dstream generation code to yield results.
+  *
+  * @tparam T - the type of object written into the DStream under test.
+  */
+case class InputStreamVerifier[T](numExpectedResults: Int,
+                                  awaitResultsTimeout : Duration =  Duration("10 second")) extends Logging  {
+
+  val notifier: TestResultNotifier[T] = TestResultNotifierFactory.getForNResults(numExpectedResults)
+
+
+  /**
+    *  Runs user-provided code that  generates a [[org.apache.spark.streaming.dstream.DStream]].
+    */
+
+  def runWithStreamingContext(streamingContext: StreamingContext,
+                              blockToRun: (StreamingContext) => DStream[T]): Unit = {
+
+    try {
+      val stream: DStream[T] = blockToRun(streamingContext)
+      stream.foreachRDD {
+        rdd => {
+          rdd.foreach { case (item) =>
+            notifier.recordResult(item)
+          }
+        }
+      }
+      println(s"===: starting $streamingContext")
+      Thread.sleep(200) // give some time to clean up (SPARK-1603)
+      streamingContext.start()
+    } catch {
+      case  e: Throwable =>
+        if (streamingContext.getState() == StreamingContextState.STOPPED) {
+          streamingContext.stop(stopSparkContext = false)
+        }
+        throw e
+    }
+  }
+
+  /**
+    *  Returns the Future[List] produced by calling [[TestResultNotifier.getResults]], which in turn will
+    *  yield the results of executing the user-suplied code block in [[runWithStreamingContext()]].
+    */
+  def awaitAndVerifyResults(streamingContext: StreamingContext, expected: List[T]): Unit = {
+    try {
+      val result: Future[List[T]] = notifier.getResults
+      System.out.println("awaitResultsTimeout:" + awaitResultsTimeout);
+      val completedResult: Future[List[T]] =  Await.ready(result,  awaitResultsTimeout)
+      System.out.println("await done")
+      val tuples = completedResult.value.get.get.toSet
+
+      val expectedResultsAsSet = expected.toSet
+      if (!tuples.equals(expectedResultsAsSet)) {
+        throw new RuntimeException(s"actual result [ $tuples ] != expected result [ $expectedResultsAsSet ]")
+      }
+      println(s"===: stopping $streamingContext")
+    } finally {
+      streamingContext.stop(stopSparkContext = false)
+      Thread.sleep(200) // give some time to clean up (SPARK-1603)
+    }
+  }
+}

--- a/src/main/2.0/scala/com/holdenkarau/spark/testing/receiver/InputStreamVerifier.scala
+++ b/src/main/2.0/scala/com/holdenkarau/spark/testing/receiver/InputStreamVerifier.scala
@@ -50,7 +50,7 @@ case class InputStreamVerifier[T]
       Thread.sleep(200) // give some time to clean up (SPARK-1603)
       streamingContext.start()
     } catch {
-      case e: Throwable =>
+      case e: Exception =>
         if (streamingContext.getState() == StreamingContextState.STOPPED) {
           streamingContext.stop(stopSparkContext = false)
         }

--- a/src/main/2.0/scala/com/holdenkarau/spark/testing/receiver/InputStreamVerifier.scala
+++ b/src/main/2.0/scala/com/holdenkarau/spark/testing/receiver/InputStreamVerifier.scala
@@ -42,7 +42,6 @@ case class InputStreamVerifier[T](numExpectedResults: Int,
           }
         }
       }
-      println(s"===: starting $streamingContext")
       Thread.sleep(200) // give some time to clean up (SPARK-1603)
       streamingContext.start()
     } catch {
@@ -61,16 +60,13 @@ case class InputStreamVerifier[T](numExpectedResults: Int,
   def awaitAndVerifyResults(streamingContext: StreamingContext, expected: List[T]): Unit = {
     try {
       val result: Future[List[T]] = notifier.getResults
-      System.out.println("awaitResultsTimeout:" + awaitResultsTimeout);
       val completedResult: Future[List[T]] =  Await.ready(result,  awaitResultsTimeout)
-      System.out.println("await done")
       val tuples = completedResult.value.get.get.toSet
 
       val expectedResultsAsSet = expected.toSet
       if (!tuples.equals(expectedResultsAsSet)) {
         throw new RuntimeException(s"actual result [ $tuples ] != expected result [ $expectedResultsAsSet ]")
       }
-      println(s"===: stopping $streamingContext")
     } finally {
       streamingContext.stop(stopSparkContext = false)
       Thread.sleep(200) // give some time to clean up (SPARK-1603)

--- a/src/main/2.0/scala/com/holdenkarau/spark/testing/receiver/InputStreamVerifier.scala
+++ b/src/main/2.0/scala/com/holdenkarau/spark/testing/receiver/InputStreamVerifier.scala
@@ -2,32 +2,37 @@ package com.holdenkarau.spark.testing.receiver
 
 import org.apache.spark.Logging
 import org.apache.spark.streaming.dstream.DStream
-import org.apache.spark.streaming.{Seconds, StreamingContext, StreamingContextState}
+import org.apache.spark.streaming.{StreamingContext, StreamingContextState}
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 
 /**
-  *  Runs user-provided code that  generates a [[org.apache.spark.streaming.dstream.DStream]], after which point
-  *  awaitAndVerifyResults() may be called to block until
-  *  [[com.holdenkarau.spark.testing.receiver.InputStreamVerifier.numExpectedResults]]
-  *  items appear in the directory where results are recorded.
+  * Runs user-provided code that  generates a
+  * [[org.apache.spark.streaming.dstream.DStream]], after which point
+  * awaitAndVerifyResults() may be called to block until
+  * [[com.holdenkarau.spark.testing.receiver.InputStreamVerifier.numExpectedResults]]
+  * items appear in the directory where results are recorded.
   *
-  * @param numExpectedResults - the number of individual items that the user-provided Dstream generation code is
-  *                           expected to yield.
-  *
-  * @param awaitResultsTimeout - the amount of time to wait for user-provided Dstream generation code to yield results.
-  *
+  * @param numExpectedResults  - the number of individual items that the
+  *                            user-provided Dstream generation code is
+  *                            expected to yield.
+  * @param awaitResultsTimeout - the amount of time to wait for user-provided
+  *                            Dstream generation code to yield results.
   * @tparam T - the type of object written into the DStream under test.
   */
-case class InputStreamVerifier[T](numExpectedResults: Int,
-                                  awaitResultsTimeout : Duration =  Duration("10 second")) extends Logging  {
+case class InputStreamVerifier[T]
+(numExpectedResults: Int,
+ awaitResultsTimeout: Duration = Duration("10 second")
+) extends Logging {
 
-  val notifier: TestResultNotifier[T] = TestResultNotifierFactory.getForNResults(numExpectedResults)
+  val notifier: TestResultNotifier[T] =
+    TestResultNotifierFactory.getForNResults(numExpectedResults)
 
 
   /**
-    *  Runs user-provided code that  generates a [[org.apache.spark.streaming.dstream.DStream]].
+    * Runs user-provided code that  generates
+    * a [[org.apache.spark.streaming.dstream.DStream]].
     */
 
   def runWithStreamingContext(streamingContext: StreamingContext,
@@ -45,7 +50,7 @@ case class InputStreamVerifier[T](numExpectedResults: Int,
       Thread.sleep(200) // give some time to clean up (SPARK-1603)
       streamingContext.start()
     } catch {
-      case  e: Throwable =>
+      case e: Throwable =>
         if (streamingContext.getState() == StreamingContextState.STOPPED) {
           streamingContext.stop(stopSparkContext = false)
         }
@@ -54,18 +59,22 @@ case class InputStreamVerifier[T](numExpectedResults: Int,
   }
 
   /**
-    *  Returns the Future[List] produced by calling [[TestResultNotifier.getResults]], which in turn will
-    *  yield the results of executing the user-suplied code block in [[runWithStreamingContext()]].
+    * Returns the Future[List] produced by calling
+    * [[TestResultNotifier.getResults]], which in turn will
+    * yield the results of executing the user-suplied
+    * code block in [[runWithStreamingContext()]].
     */
-  def awaitAndVerifyResults(streamingContext: StreamingContext, expected: List[T]): Unit = {
+  def awaitAndVerifyResults(streamingContext: StreamingContext,
+                            expected: List[T]): Unit = {
     try {
       val result: Future[List[T]] = notifier.getResults
-      val completedResult: Future[List[T]] =  Await.ready(result,  awaitResultsTimeout)
+      val completedResult: Future[List[T]] = Await.ready(result, awaitResultsTimeout)
       val tuples = completedResult.value.get.get.toSet
 
       val expectedResultsAsSet = expected.toSet
       if (!tuples.equals(expectedResultsAsSet)) {
-        throw new RuntimeException(s"actual result [ $tuples ] != expected result [ $expectedResultsAsSet ]")
+        throw new RuntimeException(
+          s"actual result [ $tuples ] != expected result [ $expectedResultsAsSet ]")
       }
     } finally {
       streamingContext.stop(stopSparkContext = false)

--- a/src/main/2.0/scala/com/holdenkarau/spark/testing/receiver/TestResultNotifier.scala
+++ b/src/main/2.0/scala/com/holdenkarau/spark/testing/receiver/TestResultNotifier.scala
@@ -13,29 +13,38 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{Future, Promise}
 
 /**
-  * Provides a mechanism that records -- into a temp directory in the local file system -- the results of running
-  * user-provided code that generates a [[org.apache.spark.streaming.dstream.DStream]], as well as a getResults()
-  * method which returns a [[Future]] that provides access to a list of those recorded results.
+  * Provides a mechanism that records -- into a temp directory in the local file
+  * system -- the results of running user-provided code that generates a
+  * [[org.apache.spark.streaming.dstream.DStream]], as well as a getResults()
+  * method which returns a [[Future]] that provides access to a list of those
+  * recorded results.
   *
-  * Note that the temp directory will be deleted after getResults() is called.  We could consider replacing the
-  * heavyweight method of writing to files by a lighter weight mechanism like broadcast variables in a subsequent
+  * Note that the temp directory will be deleted after getResults() is called.
+  * We could consider replacing the heavyweight method of writing to files by
+  * a lighter weight mechanism like broadcast variables in a subsequent
   * release (although our first attempt at this failed.)
   *
   * @param resultsDirPath - path of the directory where results will be written.
   *
-  * @param numExpectedResults - the number of individual items that the code under test is expected to write into
-  *                           the [[org.apache.spark.streaming.dstream.DStream]] it produces. Note that the value
-  *                           of this parameter will most typically be calculated from the number of elements in the
-  *                           list passed as
-  *                           [[com.holdenkarau.spark.testing.receiver.InputStreamTestingContext.dStreamCreationFunc()]].)
+  * @param numExpectedResults - the number of individual items that the code
+  *                           under test is expected to write into
+  *                           the [[org.apache.spark.streaming.dstream.DStream]]
+  *                           it produces. Note that the value of this parameter will
+  *                           most typically be calculated from the number of
+  *                           elements in the list passed as
+  *                           [[InputStreamTestingContext.dStreamCreationFunc()]].)
   *
   *
   * @tparam T - the type of object written into the DStream under test.
   */
 class TestResultNotifier[T](val resultsDirPath: String,
-                            val numExpectedResults: Int) extends Logging  with Serializable {
-  private[receiver] val resultsDataFilePath: String = resultsDirPath + File.separator + "results.dat"
-  private[receiver] val doneSentinelFilePath: String = resultsDirPath + File.separator + "results.done"
+                            val numExpectedResults: Int)
+  extends Logging  with Serializable {
+
+  private[receiver] val resultsDataFilePath: String =
+    resultsDirPath + File.separator + "results.dat"
+  private[receiver] val doneSentinelFilePath: String =
+    resultsDirPath + File.separator + "results.done"
 
   def countOfResultsEqualsExpected(resultsDirPath: String): Boolean = {
     val foundList = new File(resultsDirPath).listFiles.filter{
@@ -48,9 +57,9 @@ class TestResultNotifier[T](val resultsDirPath: String,
   }
 
   /**
-    * Use Java serialization to write out an item produced by  user-provided code that generates a
-    * [[org.apache.spark.streaming.dstream.DStream]] to a directory which will be monitored by the
-    * getResults method.
+    * Use Java serialization to write out an item produced by  user-provided code
+    * that generates a [[org.apache.spark.streaming.dstream.DStream]] to a
+    * directory which will be monitored by the getResults method.
     *
     * @param result - the item to record
     */
@@ -59,7 +68,8 @@ class TestResultNotifier[T](val resultsDirPath: String,
     logInfo(s"TestResultNotifier recording results: $result")
 
     try {
-      val fos = new FileOutputStream(new File (resultsDataFilePath +  UUID.randomUUID().toString))
+      val fos = new FileOutputStream(
+        new File (resultsDataFilePath +  UUID.randomUUID().toString))
       val oos = new ObjectOutputStream(fos);
       oos.writeObject(result)
       oos.close()
@@ -68,15 +78,18 @@ class TestResultNotifier[T](val resultsDirPath: String,
       }
     } catch {
       case  e: Throwable=>
-        throw new RuntimeException(s"util.TestResultNotifier could not record result: $result", e)
+        throw new RuntimeException(
+          s"util.TestResultNotifier could not record result: $result", e)
     }
   }
 
   /**
-    * Returns a Future which provides access to  a List of all items recorded by the recordResult() method. The Future
-    * will be completed when the number of items record reaches
-    * [[com.holdenkarau.spark.testing.receiver.TestResultNotifier.numExpectedResults]]. If more than this number of
-    * items is written the extra items are not guaranteed to be present in the Future[List] returned by this method.
+    * Returns a Future which provides access to  a List of all items recorded by
+    * the recordResult() method. The Future will be completed when the number
+    * of items record reaches
+    * [[TestResultNotifier.numExpectedResults]]. If more than this number of
+    * items is written the extra items are not guaranteed to be present
+    * in the Future[List] returned by this method.
     */
   def getResults : Future[List[T]] = {
     val promise = Promise[List[T]]()
@@ -89,10 +102,14 @@ class TestResultNotifier[T](val resultsDirPath: String,
         while (results == null) {
           if (sentinelFile.exists()) {
             val buffer = new ListBuffer[T]()
-            val filesToCheck = new File(resultsDirPath).listFiles. filter { f => ! f.getName.endsWith("done") }.toList
+            val filesToCheck =
+              new File(resultsDirPath).
+                listFiles.
+                filter { f => ! f.getName.endsWith("done") }.toList
             logInfo(s"checking files: $filesToCheck")
             for (file: File <- filesToCheck) {
-              val ois = new ObjectInputStream(new FileInputStream(file.getAbsolutePath))
+              val inputStream = new FileInputStream(file.getAbsolutePath)
+              val ois = new ObjectInputStream(inputStream)
               val result: T = ois.readObject().asInstanceOf[T]
               buffer += result
               ois.close()
@@ -108,7 +125,7 @@ class TestResultNotifier[T](val resultsDirPath: String,
       } catch {
         case  e: Throwable=>
           logError(s"util.TestResultNotifier could get results", e)
-          promise.failure(e)        // TODO - test this path by manually deleting directory
+          promise.failure(e)
       }
 
       promise.success(results)

--- a/src/main/2.0/scala/com/holdenkarau/spark/testing/receiver/TestResultNotifier.scala
+++ b/src/main/2.0/scala/com/holdenkarau/spark/testing/receiver/TestResultNotifier.scala
@@ -1,0 +1,132 @@
+package com.holdenkarau.spark.testing.receiver
+
+import java.io._
+import java.nio.file.Path
+import java.util.UUID
+
+import org.apache.commons.io.FileUtils
+import org.apache.spark.Logging
+import org.slf4j.LoggerFactory
+
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{Future, Promise}
+
+/**
+  * Provides a mechanism that records -- into a temp directory in the local file system -- the results of running
+  * user-provided code that generates a [[org.apache.spark.streaming.dstream.DStream]], as well as a getResults()
+  * method which returns a [[Future]] that provides access to a list of those recorded results.
+  *
+  * Note that the temp directory will be deleted after getResults() is called.  We could consider replacing the
+  * heavyweight method of writing to files by a lighter weight mechanism like broadcast variables in a subsequent
+  * release (although our first attempt at this failed.)
+  *
+  * @param resultsDirPath - path of the directory where results will be written.
+  *
+  * @param numExpectedResults - the number of individual items that the code under test is expected to write into
+  *                           the [[org.apache.spark.streaming.dstream.DStream]] it produces. Note that the value
+  *                           of this parameter will most typically be calculated from the number of elements in the
+  *                           list passed as
+  *                           [[com.holdenkarau.spark.testing.receiver.InputStreamTestingContext.dStreamCreationFunc()]].)
+  *
+  *
+  * @tparam T - the type of object written into the DStream under test.
+  */
+class TestResultNotifier[T](val resultsDirPath: String,
+                            val numExpectedResults: Int) extends Logging  with Serializable {
+  private[receiver] val resultsDataFilePath: String = resultsDirPath + File.separator + "results.dat"
+  private[receiver] val doneSentinelFilePath: String = resultsDirPath + File.separator + "results.done"
+
+  def countOfResultsEqualsExpected(resultsDirPath: String): Boolean = {
+    val foundList = new File(resultsDirPath).listFiles.filter{
+      file =>
+        println(s"${Thread.currentThread().getName} -- examinging: $file")
+        file.isFile
+    }.toList
+
+    foundList.length >= numExpectedResults
+  }
+
+  /**
+    * Use Java serialization to write out an item produced by  user-provided code that generates a
+    * [[org.apache.spark.streaming.dstream.DStream]] to a directory which will be monitored by the
+    * getResults method.
+    *
+    * @param result - the item to record
+    */
+  def recordResult(result: T): Unit = {
+    val logger = LoggerFactory.getLogger(getClass)
+    logInfo(s"TestResultNotifier recording results: $result")
+
+    try {
+      val fos = new FileOutputStream(new File (resultsDataFilePath +  UUID.randomUUID().toString))
+      val oos = new ObjectOutputStream(fos);
+      oos.writeObject(result)
+      oos.close()
+      if (countOfResultsEqualsExpected(resultsDirPath)) {
+        new File (doneSentinelFilePath).mkdir()   // sentinel file: marks as 'done'
+      }
+    } catch {
+      case  e: Throwable=>
+        throw new RuntimeException(s"util.TestResultNotifier could not record result: $result", e)
+    }
+  }
+
+  /**
+    * Returns a Future which provides access to  a List of all items recorded by the recordResult() method. The Future
+    * will be completed when the number of items record reaches
+    * [[com.holdenkarau.spark.testing.receiver.TestResultNotifier.numExpectedResults]]. If more than this number of
+    * items is written the extra items are not guaranteed to be present in the Future[List] returned by this method.
+    */
+  def getResults : Future[List[T]] = {
+    val promise = Promise[List[T]]()
+    val sentinelFile = new File(doneSentinelFilePath)
+    val logger = LoggerFactory.getLogger(getClass)
+
+    Future {
+      var results : List[T] =  null
+      try {
+        while (results == null) {
+          if (sentinelFile.exists()) {
+            val buffer = new ListBuffer[T]()
+            val filesToCheck = new File(resultsDirPath).listFiles. filter { f => ! f.getName.endsWith("done") }.toList
+            logInfo(s"checking files: $filesToCheck")
+            for (file: File <- filesToCheck) {
+              val ois = new ObjectInputStream(new FileInputStream(file.getAbsolutePath))
+              val result: T = ois.readObject().asInstanceOf[T]
+              buffer += result
+              ois.close()
+            }
+            results = buffer.toList
+            logInfo(s"returning results: $results")
+            FileUtils.deleteDirectory(new File(resultsDirPath));
+          } else {
+            logDebug(s"no sentinel file at $sentinelFile yet")
+          }
+          Thread.sleep(10)
+        }
+      } catch {
+        case  e: Throwable=>
+          logError(s"util.TestResultNotifier could get results", e)
+          promise.failure(e)        // TODO - test this path by manually deleting directory
+      }
+
+      promise.success(results)
+    }
+    promise.future
+  }
+}
+
+/**
+  * Factory for a TestResultNotifier which creates the temp directory into which results will be recorded, and
+  * initializes the  TestResultNotifier to expect the given number of result items to be written into this directory.
+  */
+
+object TestResultNotifierFactory extends Logging {
+  def getForNResults[T](numExpectedResults: Int): TestResultNotifier[T] = {
+    var dir: Path = java.nio.file.Files.createTempDirectory("test-results")
+    val path: String = dir.toAbsolutePath.toString
+    logInfo(s"initializing TestResultNotifier pointed to this directory: $path")
+    new TestResultNotifier[T](path, numExpectedResults)
+  }
+}

--- a/src/main/2.0/scala/com/holdenkarau/spark/testing/receiver/package.scala
+++ b/src/main/2.0/scala/com/holdenkarau/spark/testing/receiver/package.scala
@@ -1,47 +1,59 @@
 package com.holdenkarau.spark.testing
 
+
+import com.holdenkarau.spark.testing.receiver.InputStreamTestingContext
+
 /**
   *
-  * Provides support for testing [[org.apache.spark.streaming.dstream.InputDStream]]s (which are typically associated
-  * with [[org.apache.spark.streaming.receiver.Receiver]]s, hence the package name) using the pattern
-  * below for each individual test in test suites extending from
+  * Provides support for testing [[org.apache.spark.streaming.dstream.InputDStream]]s
+  * (which are typically associated with
+  * [[org.apache.spark.streaming.receiver.Receiver]]s, hence the package name)
+  * using the pattern below for each individual test in test suites extending from
   * [[com.holdenkarau.spark.testing.receiver.InputStreamSuiteBase]].
   *
   *
-  *  - create a [[org.apache.spark.streaming.StreamingContext]] from the [[org.apache.spark.SparkContext]]
+  *  - create a [[org.apache.spark.streaming.StreamingContext]] from the
+  *  [[org.apache.spark.SparkContext]]
   *  provided by [com.holdenkarau.spark.testing.SharedSparkContext]]
   *
-  *  - execute a user-provided code block that transforms the framework-provided StreamingContext into a
+  *  - execute a user-provided code block that transforms the framework-provided
+  *  StreamingContext into a
   *  [[org.apache.spark.streaming.dstream.DStream]]
-  *  (see [[com.holdenkarau.spark.testing.receiver.InputStreamTestingContext.dStreamCreationFunc()]])
+  *  (see [[InputStreamTestingContext.dStreamCreationFunc()]])
   *
   *
-  *  - after waiting for a configurable interval for the aforementioned code block to begin processing,
-  *  execute a second block of code that generates test data to be consumed by the
-  *  [[org.apache.spark.streaming.dstream.InputDStream]] under test.
-  *  (see [[com.holdenkarau.spark.testing.receiver.InputStreamTestingContext.pauseDuration]])
+  *  - after waiting for a configurable interval for the aforementioned code block
+  *  to begin processing, execute a second block of code that generates test data to
+  *  be consumed by the [[org.apache.spark.streaming.dstream.InputDStream]] under
+  *  test. (see [[InputStreamTestingContext.pauseDuration]])
   *
-  *  - compare the items encountered in the [[org.apache.spark.streaming.dstream.DStream]] produced by the first code
+  *  - compare the items encountered in the
+  *  [[org.apache.spark.streaming.dstream.DStream]] produced by the first code
   *  block to a user specified list of expected items.
   *
-  *  - stop the [[org.apache.spark.streaming.StreamingContext]] created during the first step.
+  *  - stop the [[org.apache.spark.streaming.StreamingContext]] created during the
+  *  first step.
   *
   *
   *  Implementation Overview
   *
-  * The testing process is kicked off by the construction of a InputStreamTestingContext, which wraps
+  * The testing process is kicked off by the construction of a
+  * InputStreamTestingContext, which wraps
   * user provided code and configuration options
-  * (such as  [[com.holdenkarau.spark.testing.receiver.InputStreamTestingContext.dStreamCreationFunc()]]), and the
-  * [[com.holdenkarau.spark.testing.receiver.InputStreamTestingContext.pauseDuration]])),
+  * (such as
+  * [[InputStreamTestingContext.dStreamCreationFunc()]]), and the
+  * [[InputStreamTestingContext.pauseDuration]])),
   *
-  * The framework will grab each item produced by the DStream and record it in the local file system using
+  * The framework will grab each item produced by the
+  * DStream and record it in the local file system using
   * a [[com.holdenkarau.spark.testing.receiver.TestResultNotifier]]
   *
   *
   * Known Issues:
   *
-  *   -  verification against expected results ignores ordering of elements and disregards duplicates
-  *     since the list of expected elements is turned into a set and compared against the actual results (which are
+  *   -  verification against expected results ignores ordering of elements
+  *   and disregards duplicates since the list of expected elements is
+  *   turned into a set and compared against the actual results (which are
   *     also converted to a set.)
   *
   */

--- a/src/main/2.0/scala/com/holdenkarau/spark/testing/receiver/package.scala
+++ b/src/main/2.0/scala/com/holdenkarau/spark/testing/receiver/package.scala
@@ -1,0 +1,48 @@
+package com.holdenkarau.spark.testing
+
+/**
+  *
+  * Provides support for testing [[org.apache.spark.streaming.dstream.InputDStream]]s (which are typically associated
+  * with [[org.apache.spark.streaming.receiver.Receiver]]s, hence the package name) using the pattern
+  * below for each individual test in test suites extending from
+  * [[com.holdenkarau.spark.testing.receiver.InputStreamSuiteBase]].
+  *
+  *
+  *  - create a [[org.apache.spark.streaming.StreamingContext]] from the [[org.apache.spark.SparkContext]]
+  *  provided by [com.holdenkarau.spark.testing.SharedSparkContext]]
+  *
+  *  - execute a user-provided code block that transforms the framework-provided StreamingContext into a
+  *  [[org.apache.spark.streaming.dstream.DStream]]
+  *  (see [[com.holdenkarau.spark.testing.receiver.InputStreamTestingContext.dStreamCreationFunc()]])
+  *
+  *
+  *  - after waiting for a configurable interval for the aforementioned code block to begin processing,
+  *  execute a second block of code that generates test data to be consumed by the
+  *  [[org.apache.spark.streaming.dstream.InputDStream]] under test.
+  *  (see [[com.holdenkarau.spark.testing.receiver.InputStreamTestingContext.pauseDuration]])
+  *
+  *  - compare the items encountered in the [[org.apache.spark.streaming.dstream.DStream]] produced by the first code
+  *  block to a user specified list of expected items.
+  *
+  *  - stop the [[org.apache.spark.streaming.StreamingContext]] created during the first step.
+  *
+  *
+  *  Implementation Overview
+  *
+  * The testing process is kicked off by the construction of a InputStreamTestingContext, which wraps
+  * user provided code and configuration options
+  * (such as  [[com.holdenkarau.spark.testing.receiver.InputStreamTestingContext.dStreamCreationFunc()]]), and the
+  * [[com.holdenkarau.spark.testing.receiver.InputStreamTestingContext.pauseDuration]])),
+  *
+  * The framework will grab each item produced by the DStream and record it in the local file system using
+  * a [[com.holdenkarau.spark.testing.receiver.TestResultNotifier]]
+  *
+  *
+  * Known Issues:
+  *
+  *   -  verification against expected results ignores ordering of elements and disregards duplicates
+  *     since the list of expected elements is turned into a set and compared against the actual results (which are
+  *     also converted to a set.)
+  *
+  */
+package object receiver { }

--- a/src/test/2.0/scala/com/holdenkarau/spark/testing/InputStreamTest.scala
+++ b/src/test/2.0/scala/com/holdenkarau/spark/testing/InputStreamTest.scala
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.holdenkarau.spark.testing
+
+import com.holdenkarau.spark.testing.receiver.{InputStreamSuiteBase, InputStreamTestingContext}
+import org.apache.spark.SparkContext
+import org.apache.spark.streaming.dstream.DStream
+import org.apache.spark.streaming._
+import org.scalatest.FunSuite
+
+
+
+class InputStreamTest extends FunSuite with InputStreamSuiteBase {
+
+  test("verify success if inputs received within expected timeout") {
+    runTest(
+      inputDataForDstream = List(1, 3),
+      expectedResult = List(1, 3),  
+      generatorDelay = Seconds(0),
+      awaitResultsTimeout =  Seconds(10))
+  }
+
+  test("verify failure if inputs not received within expected timeout") {
+    val thrown = intercept[Exception] {
+      runTest(
+        inputDataForDstream = List(1, 3),
+        expectedResult = List(1, 3),
+        generatorDelay = Seconds(10),
+        awaitResultsTimeout =  Seconds(0))
+    }
+    assert(thrown.getMessage contains  "Futures timed out")
+  }
+
+  test("verify error raised if execpted results do not equal actual results obtained") {
+    val thrown = intercept[Exception] {
+      runTest(inputDataForDstream = List(1, 5), expectedResult = List(1, 3))
+    }
+    assert(thrown.getMessage contains  "!= expected result")
+  }
+
+  test("show that framework does not currently detect duplicates and order discrepancies when checking results") {
+    runTest(inputDataForDstream = List(2, 2, 1), expectedResult = List(1, 2))
+  }
+
+  def runTest(inputDataForDstream: List[Int],
+              expectedResult: List[Int],
+              batchDuration: Duration = Seconds(1),
+              generatorDelay: Duration = Seconds(0),
+              awaitResultsTimeout : Duration =  Seconds(10)): Unit = {
+    val dstreamCreationFunc: (StreamingContext) => DStream[Int] = {
+      (ssc: StreamingContext) =>
+        val customCtx = ssc.asInstanceOf[StreamingContextWithExtraInputStreamGenerators[Int]]
+        customCtx.constantStream(inputDataForDstream, generatorDelay)
+    }
+
+    val noOpTestDataGenerationFunc: () => Unit = { () => }
+
+    val streamingCtxCreator =
+      (sc: SparkContext) => new StreamingContextWithExtraInputStreamGenerators(sc, null, Duration(1000))
+
+    InputStreamTestingContext(
+      sparkContext = sc,
+      dStreamCreationFunc = dstreamCreationFunc,
+      testDataGenerationFunc = noOpTestDataGenerationFunc,
+      pauseDuration = scala.concurrent.duration.Duration("1500 milliseconds"),
+      expectedResult = expectedResult,
+      streamingContextCreatorFunc = Some(streamingCtxCreator),
+      awaitResultsTimeout = awaitResultsTimeout,
+      batchDuration = batchDuration)
+      .run()
+  }
+
+}
+

--- a/src/test/2.0/scala/com/holdenkarau/spark/testing/InputStreamTest.scala
+++ b/src/test/2.0/scala/com/holdenkarau/spark/testing/InputStreamTest.scala
@@ -16,12 +16,12 @@
  */
 package com.holdenkarau.spark.testing
 
-import com.holdenkarau.spark.testing.receiver.{InputStreamSuiteBase, InputStreamTestingContext}
+import com.holdenkarau.spark.testing.receiver.InputStreamTestingContext
+import com.holdenkarau.spark.testing.receiver.InputStreamSuiteBase
 import org.apache.spark.SparkContext
-import org.apache.spark.streaming.dstream.DStream
 import org.apache.spark.streaming._
+import org.apache.spark.streaming.dstream.DStream
 import org.scalatest.FunSuite
-
 
 
 class InputStreamTest extends FunSuite with InputStreamSuiteBase {
@@ -29,9 +29,9 @@ class InputStreamTest extends FunSuite with InputStreamSuiteBase {
   test("verify success if inputs received within expected timeout") {
     runTest(
       inputDataForDstream = List(1, 3),
-      expectedResult = List(1, 3),  
+      expectedResult = List(1, 3),
       generatorDelay = Seconds(0),
-      awaitResultsTimeout =  Seconds(10))
+      awaitResultsTimeout = Seconds(10))
   }
 
   test("verify failure if inputs not received within expected timeout") {
@@ -40,19 +40,20 @@ class InputStreamTest extends FunSuite with InputStreamSuiteBase {
         inputDataForDstream = List(1, 3),
         expectedResult = List(1, 3),
         generatorDelay = Seconds(10),
-        awaitResultsTimeout =  Seconds(0))
+        awaitResultsTimeout = Seconds(0))
     }
-    assert(thrown.getMessage contains  "Futures timed out")
+    assert(thrown.getMessage contains "Futures timed out")
   }
 
-  test("verify error raised if execpted results do not equal actual results obtained") {
+  test("verify error raised if execpted results do not equal actual results") {
     val thrown = intercept[Exception] {
       runTest(inputDataForDstream = List(1, 5), expectedResult = List(1, 3))
     }
-    assert(thrown.getMessage contains  "!= expected result")
+    assert(thrown.getMessage contains "!= expected result")
   }
 
-  test("show that framework does not currently detect duplicates and order discrepancies when checking results") {
+  test("show that framework does not " +
+    "currently detect duplicates and order discrepancies when checking results") {
     runTest(inputDataForDstream = List(2, 2, 1), expectedResult = List(1, 2))
   }
 
@@ -60,17 +61,19 @@ class InputStreamTest extends FunSuite with InputStreamSuiteBase {
               expectedResult: List[Int],
               batchDuration: Duration = Seconds(1),
               generatorDelay: Duration = Seconds(0),
-              awaitResultsTimeout : Duration =  Seconds(10)): Unit = {
+              awaitResultsTimeout: Duration = Seconds(10)): Unit = {
     val dstreamCreationFunc: (StreamingContext) => DStream[Int] = {
       (ssc: StreamingContext) =>
-        val customCtx = ssc.asInstanceOf[StreamingContextWithExtraInputStreamGenerators[Int]]
+        val customCtx =
+          ssc.asInstanceOf[StreamingContextWithExtraInputStreamGenerators[Int]]
         customCtx.constantStream(inputDataForDstream, generatorDelay)
     }
 
     val noOpTestDataGenerationFunc: () => Unit = { () => }
 
     val streamingCtxCreator =
-      (sc: SparkContext) => new StreamingContextWithExtraInputStreamGenerators(sc, null, Duration(1000))
+      (sc: SparkContext) =>
+        new StreamingContextWithExtraInputStreamGenerators(sc, null, Duration(1000))
 
     InputStreamTestingContext(
       sparkContext = sc,
@@ -79,7 +82,7 @@ class InputStreamTest extends FunSuite with InputStreamSuiteBase {
       pauseDuration = scala.concurrent.duration.Duration("1500 milliseconds"),
       expectedResult = expectedResult,
       streamingContextCreatorFunc = Some(streamingCtxCreator),
-      awaitResultsTimeout = awaitResultsTimeout,
+      awaitTimeout = awaitResultsTimeout,
       batchDuration = batchDuration)
       .run()
   }

--- a/src/test/2.0/scala/org/apache/spark/streaming/StreamingContextWithExtraInputStreamGenerators.scala
+++ b/src/test/2.0/scala/org/apache/spark/streaming/StreamingContextWithExtraInputStreamGenerators.scala
@@ -8,21 +8,25 @@ import scala.collection.mutable
 import scala.reflect.ClassTag
 
 
-// Test with empty RDD
+// TODO - Test with empty RDD
 //
 
 /**
-  *  Provides the [[constantStream]] method which  generates an  InputDStream whose configurable delay characteristics
-  *  and contents are useful for testing.
+  * Provides the [[constantStream]] method which  generates an
+  * InputDStream whose configurable delay characteristics and
+  * contents are useful for testing.
   */
-class StreamingContextWithExtraInputStreamGenerators [T: ClassTag] (sc_ : SparkContext,
-                                                                    cp_ : Checkpoint,
-                                                                    batchDuration_ : Duration)
-  extends TestStreamingContext(sc_, cp_, batchDuration_) {
+class StreamingContextWithExtraInputStreamGenerators[T: ClassTag]
+(sc_ : SparkContext,
+ cp_ : Checkpoint,
+ batchDuration_ : Duration
+) extends TestStreamingContext(sc_, cp_, batchDuration_) {
 
 
-  def constantStream(items: List[T], generatorDelay: org.apache.spark.streaming.Duration) : InputDStream[T] = {
-    val inputData  = new ThrottledQueue[RDD[T]](generatorDelay)
+  def constantStream(items: List[T],
+                     generatorDelay: org.apache.spark.streaming.Duration)
+  : InputDStream[T] = {
+    val inputData = new ThrottledQueue[RDD[T]](generatorDelay)
     require(items.length >= 2)
     inputData.enqueue(sc.makeRDD(items))
     new QueueInputDStream[T](this, inputData, oneAtATime = true, defaultRDD = null)

--- a/src/test/2.0/scala/org/apache/spark/streaming/StreamingContextWithExtraInputStreamGenerators.scala
+++ b/src/test/2.0/scala/org/apache/spark/streaming/StreamingContextWithExtraInputStreamGenerators.scala
@@ -1,0 +1,37 @@
+package org.apache.spark.streaming
+
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+import org.apache.spark.streaming.dstream.{InputDStream, QueueInputDStream}
+
+import scala.collection.mutable
+import scala.reflect.ClassTag
+
+
+// Test with empty RDD
+//
+
+/**
+  *  Provides the [[constantStream]] method which  generates an  InputDStream whose configurable delay characteristics
+  *  and contents are useful for testing.
+  */
+class StreamingContextWithExtraInputStreamGenerators [T: ClassTag] (sc_ : SparkContext,
+                                                                    cp_ : Checkpoint,
+                                                                    batchDuration_ : Duration)
+  extends TestStreamingContext(sc_, cp_, batchDuration_) {
+
+
+  def constantStream(items: List[T], generatorDelay: org.apache.spark.streaming.Duration) : InputDStream[T] = {
+    val inputData  = new ThrottledQueue[RDD[T]](generatorDelay)
+    require(items.length >= 2)
+    inputData.enqueue(sc.makeRDD(items))
+    new QueueInputDStream[T](this, inputData, oneAtATime = true, defaultRDD = null)
+  }
+}
+
+class ThrottledQueue[T](val dequeueDelay: Duration) extends mutable.Queue[T] {
+  override def dequeue(): T = {
+    Thread.sleep(dequeueDelay.milliseconds)
+    super.dequeue()
+  }
+}


### PR DESCRIPTION
Provides support for testing  InputDStreams  via the following pattern:

     - create a StreamingContext from the SparkContext 
       provided by SharedSparkContext
   
     - execute a user-provided code block that transforms the 
       framework-provided StreamingContext into a DStream
  
    - after waiting for a configurable interval for the aforementioned 
      code block to begin processing, execute a second block of 
      code that generates test data to be consumed by the InputDStream
       under test.
  
    - compare the items encountered in the DStream produced by 
       the first code block to a user specified list of expected items.