### PR TITLE
add assertRDDEquals method for python

### DIFF
--- a/python/sparktestingbase/test/simple_test.py
+++ b/python/sparktestingbase/test/simple_test.py
@@ -64,5 +64,19 @@ class SimpleTest(SparkTestingBaseTestCase):
         rdd_result   = self.sc.parallelize(input_result)
         assert self.assertRDDEquals(rdd_expected, rdd_result)  == True
 
+    def test_assertRDDEuqlsWithOrder_true(self):
+        input_expected = [1,2,3,4,5]
+        input_result   = [1,2,3,4,5]
+        rdd_expected = self.sc.parallelize(input_expected)
+        rdd_result   = self.sc.parallelize(input_result)
+        assert self.assertRDDEqualsWithOrder(rdd_expected, rdd_result) == True
+
+    def test_assertRDDEuqlsWithOrder_wrong_order_false(self):
+        input_expected = [5,4,3,2,1]
+        input_result   = [1,2,3,4,5]
+        rdd_expected = self.sc.parallelize(input_expected)
+        rdd_result   = self.sc.parallelize(input_result)
+        assert self.assertRDDEqualsWithOrder(rdd_expected, rdd_result) == False
+
 if __name__ == "__main__":
     unittest2.main()

--- a/python/sparktestingbase/test/simple_test.py
+++ b/python/sparktestingbase/test/simple_test.py
@@ -31,5 +31,38 @@ class SimpleTest(SparkTestingBaseTestCase):
         result = rdd.collect()
         assert result == input
 
+    def test_assertRDDEquals_true(self):
+        """Test a simple coleect."""
+        input_expected = ["hello world"]
+        input_result   = ["hello world"]
+        rdd_expected = self.sc.parallelize(input_expected)
+        rdd_result   = self.sc.parallelize(input_result)
+        assert self.assertRDDEquals(rdd_expected, rdd_result)  == True
+
+    def test_assertRDDEquals_inverse_terms_false(self):
+        """Test a simple coleect."""
+        input_expected = ["hello world"]
+        input_result   = ["world hello"]
+        rdd_expected = self.sc.parallelize(input_expected)
+        rdd_result   = self.sc.parallelize(input_result)
+        assert self.assertRDDEquals(rdd_expected, rdd_result)  == False
+
+
+    def test_assertRDDEquals_diff_length_false(self):
+        """Test a simple coleect."""
+        input_expected = [1,2,3,4,5]
+        input_result   = [1,2,3,4,5,6]
+        rdd_expected = self.sc.parallelize(input_expected)
+        rdd_result   = self.sc.parallelize(input_result)
+        assert self.assertRDDEquals(rdd_expected, rdd_result)  == False
+
+    def test_assertRDDEquals_inverse_list_true(self):
+        """Test a simple coleect."""
+        input_expected = [5,4,3,2,1]
+        input_result   = [1,2,3,4,5]
+        rdd_expected = self.sc.parallelize(input_expected)
+        rdd_result   = self.sc.parallelize(input_result)
+        assert self.assertRDDEquals(rdd_expected, rdd_result)  == True
+
 if __name__ == "__main__":
     unittest2.main()

--- a/python/sparktestingbase/testcase.py
+++ b/python/sparktestingbase/testcase.py
@@ -51,12 +51,16 @@ class SparkTestingBaseTestCase(unittest2.TestCase):
         self.sc._jvm.System.clearProperty("spark.driver.port")
 
     def assertRDDEquals(self, expected, result):
-        expectedKeyed = expected.map(lambda x: (x, 1)).reduceByKey(lambda x, y: x + y)
-        resultKeyed = result.map(lambda x: (x, 1)).reduceByKey(lambda x, y: x + y)
-        if False in [x==y for x, y in [tuple(map(list,y)) for x, y in expectedKeyed.cogroup(resultKeyed).collect()]]:
-            return False
-        else:
-            return True
+        return self.compareRDD(expected, result) == []
+
+    def compareRDD(self, expected, result):
+        expectedKeyed = expected.map(lambda x: (x, 1))\
+			.reduceByKey(lambda x, y: x + y)
+        resultKeyed = result.map(lambda x: (x, 1))\
+		      .reduceByKey(lambda x, y: x + y)
+        return expectedKeyed.cogroup(resultKeyed)\
+	       .map(lambda x: tuple(map(list,x[1])))\
+	       .filter(lambda x: x[0] != x[1]).take(1)
 
 class SparkTestingBaseReuse(unittest2.TestCase):
 

--- a/python/sparktestingbase/testcase.py
+++ b/python/sparktestingbase/testcase.py
@@ -50,6 +50,13 @@ class SparkTestingBaseTestCase(unittest2.TestCase):
         # immediately on shutdown
         self.sc._jvm.System.clearProperty("spark.driver.port")
 
+    def assertRDDEquals(self, expected, result):
+        expectedKeyed = expected.map(lambda x: (x, 1)).reduceByKey(lambda x, y: x + y)
+        resultKeyed = result.map(lambda x: (x, 1)).reduceByKey(lambda x, y: x + y)
+        if False in [x==y for x, y in [tuple(map(list,y)) for x, y in expectedKeyed.cogroup(resultKeyed).collect()]]:
+            return False
+        else:
+            return True
 
 class SparkTestingBaseReuse(unittest2.TestCase):
 

--- a/python/sparktestingbase/testcase.py
+++ b/python/sparktestingbase/testcase.py
@@ -62,6 +62,18 @@ class SparkTestingBaseTestCase(unittest2.TestCase):
 	       .map(lambda x: tuple(map(list,x[1])))\
 	       .filter(lambda x: x[0] != x[1]).take(1)
 
+    def assertRDDEqualsWithOrder(self, expected, result):
+        return self.compareRDDWithOrder(expected, result) == []
+    
+    def compareRDDWithOrder(self, expected, result):
+        def indexRDD(rdd):
+            return rdd.zipWithIndex().map(lambda x: (x[1], x[0]))
+        indexExpected = indexRDD(expected)
+        indexResult = indexRDD(result)
+        return indexExpected.cogroup(indexResult)\
+           .map(lambda x: tuple(map(list,x[1])))\
+           .filter(lambda x: x[0] != x[1]).take(1)
+
 class SparkTestingBaseReuse(unittest2.TestCase):
 
     """Basic common test case for Spark. Provides a Spark context as sc.


### PR DESCRIPTION
there is no function to compare two RDD in Pyspark, so I wrote a compareRDD function which is similar to it in Scala version