### PR TITLE
Add option to enable/disable hive support in DataFrameSuiteBase

### DIFF
--- a/src/main/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteBase.scala
+++ b/src/main/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteBase.scala
@@ -56,6 +56,7 @@ trait DataFrameSuiteBaseLike extends SparkContextProvider
 
   protected implicit def impSqlContext: SQLContext = sqlContext
 
+  protected implicit def enableHiveSupport: Boolean = true
 
   def sqlBeforeAllTestCases() {
     /**
@@ -88,7 +89,9 @@ trait DataFrameSuiteBaseLike extends SparkContextProvider
         localWarehousePath)
       // Enable hive support if available
       try {
-        builder.enableHiveSupport()
+        if (enableHiveSupport) {
+          builder.enableHiveSupport()
+        }
       } catch {
         // Exception is thrown in Spark if hive is not present
         case e: IllegalArgumentException =>


### PR DESCRIPTION
The PR just adds a `def enableHiveSupport = true` in `DataFrameSuiteBaseLike` to be able to enable/disable hive support from the actual TestSuite.

We have a repository with 104 test suites using DataFrameSuiteBase but we never need the hive support which is always enabled in `DataFrameSuiteBase`. The whole test suite takes more than 10 minutes to run (when it doesn't crash because of some strange exceptions). With hive support disabled, the tests take less than 5 minutes and the strange exceptions are gone.