### PR TITLE
Minor cleanups & pep8 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ cache:
     - $HOME/.cache/pip
     - $HOME/.pip-cache
     - $HOME/.sbt/launchers
+jdk:
+  - oraclejdk8
 scala:
    - 2.10.4
 sudo: false

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ This is not my beautiful code.
 
 ## How?
 
-So you include com.holdenkarau.spark-testing-base [spark_version]_0.6.0 and extend one of the classes and write some simple tests instead.  For example to include this in a project using Spark 2.1.0:
+So you include com.holdenkarau.spark-testing-base [spark_version]_0.7.0 and extend one of the classes and write some simple tests instead.  For example to include this in a project using Spark 2.1.1:
 
 ```scala
-"com.holdenkarau" %% "spark-testing-base" % "2.1.0_0.6.0" % "test"
+"com.holdenkarau" %% "spark-testing-base" % "2.1.1_0.7.0" % "test"
 ```
 
 or
@@ -24,7 +24,7 @@ or
 <dependency>
     <groupId>com.holdenkarau</groupId>
     <artifactId>spark-testing-base_2.11</artifactId>
-    <version>${spark.version}_0.6.0</version>
+    <version>${spark.version}_0.7.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
+#0.7
+ - Add Python RDD comparisions
+ - Switch to JDK8 for Spark 2.1.1+
+ - Add back Kafka tests
+ - Make it easier to disable Hive support when running tests
+ - Add Spark 2.1.1 to the build
+ - Misc internal style cleanup (more help always welcome!)
+ - README update
 #0.6
  - Updated scalatest dependency to 3.0.1 (from 2.X) minor breaking changes with RNG
  - Updated scalacheck to 1.13.4

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@
  - Add Spark 2.1.1 to the build
  - Misc internal style cleanup (more help always welcome!)
  - README update
+ - Some methods made protected which used to be public, recompile required.
 #0.6
  - Updated scalatest dependency to 3.0.1 (from 2.X) minor breaking changes with RNG
  - Updated scalacheck to 1.13.4

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,13 @@ crossScalaVersions := {
   }
 }
 
-javacOptions ++= Seq("-source", "1.7", "-target", "1.7")
+javacOptions ++= {
+    if (sparkVersion.value >= "2.1.1") {
+      Seq("-source", "1.8", "-target", "1.8")
+    } else {
+      Seq("-source", "1.7", "-target", "1.7")
+    }
+}
 
 //tag::spName[]
 spName := "holdenk/spark-testing-base"

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ sparkVersion := "2.1.1"
 
 scalaVersion := {
   if (sparkVersion.value >= "2.0.0") {
-    "2.11.8"
+    "2.11.11"
   } else {
     "2.10.6"
   }

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='spark-testing-base',
-    version='0.6.0',
+    version='0.7.0',
     author='Holden Karau',
     author_email='holden@pigscanfly.ca',
     packages=['sparktestingbase', 'sparktestingbase.test'],

--- a/python/sparktestingbase/__init__.py
+++ b/python/sparktestingbase/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from .utils import add_pyspark_path_if_needed
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -25,5 +26,4 @@ Helpful classes to write Spark tests.
 
 __all__ = ["SparkTestingBaseTestCase"]
 """
-from .utils import add_pyspark_path_if_needed
 add_pyspark_path_if_needed()

--- a/python/sparktestingbase/pathmagic.py
+++ b/python/sparktestingbase/pathmagic.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import
+from .utils import add_pyspark_path_if_needed
+
+"""
+Add the python path if needed as an import to make pep8 happy.
+"""
+add_pyspark_path_if_needed()

--- a/python/sparktestingbase/sqltestcase.py
+++ b/python/sparktestingbase/sqltestcase.py
@@ -25,11 +25,9 @@ from .testcase import SparkTestingBaseReuse
 import os
 import sys
 from itertools import chain
-import time
 import operator
 import tempfile
 import random
-import struct
 from functools import reduce
 
 from pyspark.context import SparkConf, SparkContext, RDD

--- a/python/sparktestingbase/sqltestcase.py
+++ b/python/sparktestingbase/sqltestcase.py
@@ -17,9 +17,7 @@ from __future__ import absolute_import
 #
 
 from .utils import add_pyspark_path_if_needed, quiet_py4j
-
-add_pyspark_path_if_needed()
-
+from .pathmagic import *
 from .testcase import SparkTestingBaseReuse
 
 import os

--- a/python/sparktestingbase/streamingtestcase.py
+++ b/python/sparktestingbase/streamingtestcase.py
@@ -17,8 +17,7 @@ from __future__ import absolute_import
 #
 
 from .utils import add_pyspark_path_if_needed, quiet_py4j
-
-add_pyspark_path_if_needed()
+from .pathmagic import *
 
 from .testcase import SparkTestingBaseReuse
 

--- a/python/sparktestingbase/test/simple_sql_test.py
+++ b/python/sparktestingbase/test/simple_sql_test.py
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-"""Simple sSQL test"""
+"""A simple SQL test case"""
 
 from datetime import datetime
 from pyspark.sql import Row

--- a/python/sparktestingbase/test/simple_streaming_test.py
+++ b/python/sparktestingbase/test/simple_streaming_test.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 """Simple streaming test"""
 
 from sparktestingbase.streamingtestcase import StreamingTestCase

--- a/python/sparktestingbase/test/simple_test.py
+++ b/python/sparktestingbase/test/simple_test.py
@@ -64,5 +64,19 @@ class SimpleTest(SparkTestingBaseTestCase):
         rdd_result   = self.sc.parallelize(input_result)
         assert self.assertRDDEquals(rdd_expected, rdd_result)  == True
 
+    def test_assertRDDEuqlsWithOrder_true(self):
+        input_expected = [1,2,3,4,5]
+        input_result   = [1,2,3,4,5]
+        rdd_expected = self.sc.parallelize(input_expected)
+        rdd_result   = self.sc.parallelize(input_result)
+        assert self.assertRDDEqualsWithOrder(rdd_expected, rdd_result) == True
+
+    def test_assertRDDEuqlsWithOrder_wrong_order_false(self):
+        input_expected = [5,4,3,2,1]
+        input_result   = [1,2,3,4,5]
+        rdd_expected = self.sc.parallelize(input_expected)
+        rdd_result   = self.sc.parallelize(input_result)
+        assert self.assertRDDEqualsWithOrder(rdd_expected, rdd_result) == False
+
 if __name__ == "__main__":
     unittest2.main()

--- a/python/sparktestingbase/test/simple_test.py
+++ b/python/sparktestingbase/test/simple_test.py
@@ -31,5 +31,38 @@ class SimpleTest(SparkTestingBaseTestCase):
         result = rdd.collect()
         assert result == input
 
+    def test_assertRDDEquals_true(self):
+        """Test a simple coleect."""
+        input_expected = ["hello world"]
+        input_result   = ["hello world"]
+        rdd_expected = self.sc.parallelize(input_expected)
+        rdd_result   = self.sc.parallelize(input_result)
+        assert self.assertRDDEquals(rdd_expected, rdd_result)  == True
+
+    def test_assertRDDEquals_inverse_terms_false(self):
+        """Test a simple coleect."""
+        input_expected = ["hello world"]
+        input_result   = ["world hello"]
+        rdd_expected = self.sc.parallelize(input_expected)
+        rdd_result   = self.sc.parallelize(input_result)
+        assert self.assertRDDEquals(rdd_expected, rdd_result)  == False
+
+
+    def test_assertRDDEquals_diff_length_false(self):
+        """Test a simple coleect."""
+        input_expected = [1,2,3,4,5]
+        input_result   = [1,2,3,4,5,6]
+        rdd_expected = self.sc.parallelize(input_expected)
+        rdd_result   = self.sc.parallelize(input_result)
+        assert self.assertRDDEquals(rdd_expected, rdd_result)  == False
+
+    def test_assertRDDEquals_inverse_list_true(self):
+        """Test a simple coleect."""
+        input_expected = [5,4,3,2,1]
+        input_result   = [1,2,3,4,5]
+        rdd_expected = self.sc.parallelize(input_expected)
+        rdd_result   = self.sc.parallelize(input_result)
+        assert self.assertRDDEquals(rdd_expected, rdd_result)  == True
+
 if __name__ == "__main__":
     unittest2.main()

--- a/python/sparktestingbase/test/simple_test.py
+++ b/python/sparktestingbase/test/simple_test.py
@@ -34,49 +34,48 @@ class SimpleTest(SparkTestingBaseTestCase):
     def test_assertRDDEquals_true(self):
         """Test a simple coleect."""
         input_expected = ["hello world"]
-        input_result   = ["hello world"]
+        input_result = ["hello world"]
         rdd_expected = self.sc.parallelize(input_expected)
-        rdd_result   = self.sc.parallelize(input_result)
-        assert self.assertRDDEquals(rdd_expected, rdd_result)  == True
+        rdd_result = self.sc.parallelize(input_result)
+        assert self.assertRDDEquals(rdd_expected, rdd_result) is True
 
     def test_assertRDDEquals_inverse_terms_false(self):
         """Test a simple coleect."""
         input_expected = ["hello world"]
-        input_result   = ["world hello"]
+        input_result = ["world hello"]
         rdd_expected = self.sc.parallelize(input_expected)
-        rdd_result   = self.sc.parallelize(input_result)
-        assert self.assertRDDEquals(rdd_expected, rdd_result)  == False
-
+        rdd_result = self.sc.parallelize(input_result)
+        assert self.assertRDDEquals(rdd_expected, rdd_result) is False
 
     def test_assertRDDEquals_diff_length_false(self):
-        """Test a simple coleect."""
-        input_expected = [1,2,3,4,5]
-        input_result   = [1,2,3,4,5,6]
+        """Test a simple collect."""
+        input_expected = [1, 2, 3, 4, 5]
+        input_result = [1, 2, 3, 4, 5, 6]
         rdd_expected = self.sc.parallelize(input_expected)
-        rdd_result   = self.sc.parallelize(input_result)
-        assert self.assertRDDEquals(rdd_expected, rdd_result)  == False
+        rdd_result = self.sc.parallelize(input_result)
+        assert self.assertRDDEquals(rdd_expected, rdd_result) is False
 
     def test_assertRDDEquals_inverse_list_true(self):
         """Test a simple coleect."""
-        input_expected = [5,4,3,2,1]
-        input_result   = [1,2,3,4,5]
+        input_expected = [5, 4, 3, 2, 1]
+        input_result = [1, 2, 3, 4, 5]
         rdd_expected = self.sc.parallelize(input_expected)
-        rdd_result   = self.sc.parallelize(input_result)
-        assert self.assertRDDEquals(rdd_expected, rdd_result)  == True
+        rdd_result = self.sc.parallelize(input_result)
+        assert self.assertRDDEquals(rdd_expected, rdd_result) is True
 
     def test_assertRDDEuqlsWithOrder_true(self):
-        input_expected = [1,2,3,4,5]
-        input_result   = [1,2,3,4,5]
+        input_expected = [1, 2, 3, 4, 5]
+        input_result = [1, 2, 3, 4, 5]
         rdd_expected = self.sc.parallelize(input_expected)
-        rdd_result   = self.sc.parallelize(input_result)
-        assert self.assertRDDEqualsWithOrder(rdd_expected, rdd_result) == True
+        rdd_result = self.sc.parallelize(input_result)
+        assert self.assertRDDEqualsWithOrder(rdd_expected, rdd_result) is True
 
     def test_assertRDDEuqlsWithOrder_wrong_order_false(self):
-        input_expected = [5,4,3,2,1]
-        input_result   = [1,2,3,4,5]
+        input_expected = [5, 4, 3, 2, 1]
+        input_result = [1, 2, 3, 4, 5]
         rdd_expected = self.sc.parallelize(input_expected)
-        rdd_result   = self.sc.parallelize(input_result)
-        assert self.assertRDDEqualsWithOrder(rdd_expected, rdd_result) == False
+        rdd_result = self.sc.parallelize(input_result)
+        assert self.assertRDDEqualsWithOrder(rdd_expected, rdd_result) is False
 
 if __name__ == "__main__":
     unittest2.main()

--- a/python/sparktestingbase/testcase.py
+++ b/python/sparktestingbase/testcase.py
@@ -55,27 +55,27 @@ class SparkTestingBaseTestCase(unittest2.TestCase):
 
     def compareRDD(self, expected, result):
         expectedKeyed = expected.map(lambda x: (x, 1))\
-			.reduceByKey(lambda x, y: x + y)
+                                .reduceByKey(lambda x, y: x + y)
         resultKeyed = result.map(lambda x: (x, 1))\
-		      .reduceByKey(lambda x, y: x + y)
+                            .reduceByKey(lambda x, y: x + y)
         return expectedKeyed.cogroup(resultKeyed)\
-	       .map(lambda x: tuple(map(list,x[1])))\
-	       .filter(lambda x: x[0] != x[1]).take(1)
+                            .map(lambda x: tuple(map(list, x[1])))\
+                            .filter(lambda x: x[0] != x[1]).take(1)
 
     def assertRDDEqualsWithOrder(self, expected, result):
         return self.compareRDDWithOrder(expected, result) == []
-    
+
     def compareRDDWithOrder(self, expected, result):
         def indexRDD(rdd):
             return rdd.zipWithIndex().map(lambda x: (x[1], x[0]))
         indexExpected = indexRDD(expected)
         indexResult = indexRDD(result)
         return indexExpected.cogroup(indexResult)\
-           .map(lambda x: tuple(map(list,x[1])))\
-           .filter(lambda x: x[0] != x[1]).take(1)
+                            .map(lambda x: tuple(map(list, x[1])))\
+                            .filter(lambda x: x[0] != x[1]).take(1)
+
 
 class SparkTestingBaseReuse(unittest2.TestCase):
-
     """Basic common test case for Spark. Provides a Spark context as sc.
     For non local mode testing you can either override sparkMaster
     or set the enviroment property SPARK_MASTER for non-local mode testing."""

--- a/python/sparktestingbase/testcase.py
+++ b/python/sparktestingbase/testcase.py
@@ -51,12 +51,16 @@ class SparkTestingBaseTestCase(unittest2.TestCase):
         self.sc._jvm.System.clearProperty("spark.driver.port")
 
     def assertRDDEquals(self, expected, result):
-        expectedKeyed = expected.map(lambda x: (x, 1)).reduceByKey(lambda x, y: x + y)
-        resultKeyed = result.map(lambda x: (x, 1)).reduceByKey(lambda x, y: x + y)
-        if False in [x==y for x, y in [tuple(map(list,y)) for x, y in expectedKeyed.cogroup(resultKeyed).collect()]]:
-            return False
-        else:
-            return True
+        return self.compareRDD(expected, result) == []
+
+    def compareRDD(self, expected, result):
+        expectedKeyed = expected.map(lambda x: (x, 1))\
+			.reduceByKey(lambda x, y: x + y)
+        resultKeyed = result.map(lambda x: (x, 1))\
+		      .reduceByKey(lambda x, y: x + y)
+        return expectedKeyed.cogroup(resultKeyed)\
+	       .map(lambda x: tuple(map(list,x[1])))\
+	       .filter(lambda x: x[0] != x[1]).take(1)
 
 class SparkTestingBaseReuse(unittest2.TestCase):
 

--- a/python/sparktestingbase/testcase.py
+++ b/python/sparktestingbase/testcase.py
@@ -50,6 +50,13 @@ class SparkTestingBaseTestCase(unittest2.TestCase):
         # immediately on shutdown
         self.sc._jvm.System.clearProperty("spark.driver.port")
 
+    def assertRDDEquals(self, expected, result):
+        expectedKeyed = expected.map(lambda x: (x, 1)).reduceByKey(lambda x, y: x + y)
+        resultKeyed = result.map(lambda x: (x, 1)).reduceByKey(lambda x, y: x + y)
+        if False in [x==y for x, y in [tuple(map(list,y)) for x, y in expectedKeyed.cogroup(resultKeyed).collect()]]:
+            return False
+        else:
+            return True
 
 class SparkTestingBaseReuse(unittest2.TestCase):
 

--- a/python/sparktestingbase/testcase.py
+++ b/python/sparktestingbase/testcase.py
@@ -62,6 +62,18 @@ class SparkTestingBaseTestCase(unittest2.TestCase):
 	       .map(lambda x: tuple(map(list,x[1])))\
 	       .filter(lambda x: x[0] != x[1]).take(1)
 
+    def assertRDDEqualsWithOrder(self, expected, result):
+        return self.compareRDDWithOrder(expected, result) == []
+    
+    def compareRDDWithOrder(self, expected, result):
+        def indexRDD(rdd):
+            return rdd.zipWithIndex().map(lambda x: (x[1], x[0]))
+        indexExpected = indexRDD(expected)
+        indexResult = indexRDD(result)
+        return indexExpected.cogroup(indexResult)\
+           .map(lambda x: tuple(map(list,x[1])))\
+           .filter(lambda x: x[0] != x[1]).take(1)
+
 class SparkTestingBaseReuse(unittest2.TestCase):
 
     """Basic common test case for Spark. Provides a Spark context as sc.

--- a/sbt/sbt
+++ b/sbt/sbt
@@ -20,7 +20,7 @@
 # This script launches sbt for this project. If present it uses the system 
 # version of sbt. If there is no system version of sbt it attempts to download
 # sbt locally.
-SBT_VERSION=0.13.9
+SBT_VERSION=0.13.15
 URL1=http://typesafe.artifactoryonline.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch.jar
 URL2=http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch.jar
 JAR=sbt/sbt-launch-${SBT_VERSION}.jar

--- a/src/main/1.3/java/com/holdenkarau/spark/testing/SharedJavaSparkContext.java
+++ b/src/main/1.3/java/com/holdenkarau/spark/testing/SharedJavaSparkContext.java
@@ -50,10 +50,10 @@ public class SharedJavaSparkContext implements SparkContextProvider {
   /**
    * Hooks for setup code that needs to be executed/torn down in order with SparkContexts
    */
-  void beforeAllTestCasesHook() {
+  protected void beforeAllTestCasesHook() {
   }
 
-  static void afterAllTestCasesHook() {
+  protected static void afterAllTestCasesHook() {
   }
 
   @Before

--- a/src/main/1.3/scala/com/holdenkarau/spark/testing/YARNCluster.scala
+++ b/src/main/1.3/scala/com/holdenkarau/spark/testing/YARNCluster.scala
@@ -72,9 +72,9 @@ trait YARNClusterLike {
     yarnCluster.foreach(_.init(yarnConf))
     yarnCluster.foreach(_.start())
 
-    val config = yarnCluster.get.getConfig()
+    val config = yarnCluster.map(_.getConfig())
     val deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(10)
-    while (config.get(YarnConfiguration.RM_ADDRESS).split(":")(1) == "0") {
+    while (config.map(_.get(YarnConfiguration.RM_ADDRESS).split(":")(1)) == Some("0")) {
       if (System.currentTimeMillis() > deadline) {
         throw new IllegalStateException("Timed out waiting for RM to come up.")
       }

--- a/src/main/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteBase.scala
+++ b/src/main/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteBase.scala
@@ -56,6 +56,7 @@ trait DataFrameSuiteBaseLike extends SparkContextProvider
 
   protected implicit def impSqlContext: SQLContext = sqlContext
 
+  protected implicit def enableHiveSupport: Boolean = true
 
   def sqlBeforeAllTestCases() {
     /**
@@ -88,7 +89,9 @@ trait DataFrameSuiteBaseLike extends SparkContextProvider
         localWarehousePath)
       // Enable hive support if available
       try {
-        builder.enableHiveSupport()
+        if (enableHiveSupport) {
+          builder.enableHiveSupport()
+        }
       } catch {
         // Exception is thrown in Spark if hive is not present
         case e: IllegalArgumentException =>


### PR DESCRIPTION
To get the release ready perform some minor cleanups, pep8 fixes, and update the version strings.

Also change new version (Spark 2.1.1+) to use JDK8 since Spark is deprecating JDK7 support going forwards.