### PR TITLE
Fixing assertDataFrameEqual and adding unit tests

### DIFF
--- a/python/sparktestingbase/sqltestcase.py
+++ b/python/sparktestingbase/sqltestcase.py
@@ -66,6 +66,7 @@ class SQLTestCase(SparkTestingBaseReuse):
         try:
             expectedRDD = expected.rdd.cache()
             resultRDD = result.rdd.cache()
+            self.assertEqual(expectedRDD.count(), resultRDD.count())
 
             def zipWithIndex(rdd):
                 """Zip with index (idx, data)"""

--- a/python/sparktestingbase/test/simple_sql_test.py
+++ b/python/sparktestingbase/test/simple_sql_test.py
@@ -81,7 +81,9 @@ class SimpleSQLTest(SQLTestCase):
             b=True, list=[1, 2, 3], dict={"s": 0}, row=Row(a=1),
             time=datetime(2014, 8, 1, 14, 1, 5))])
         empty = self.sc.parallelize([])
-        self.assertDataFrameEqual(allTypes.toDF(), self.sqlCtx.createDataFrame(empty, allTypes.toDF().schema), 0.1)
+        self.assertDataFrameEqual(
+            allTypes.toDF(),
+            self.sqlCtx.createDataFrame(empty, allTypes.toDF().schema), 0.1)
 
 
 if __name__ == "__main__":

--- a/python/sparktestingbase/test/simple_sql_test.py
+++ b/python/sparktestingbase/test/simple_sql_test.py
@@ -18,12 +18,18 @@
 
 from datetime import datetime
 from pyspark.sql import Row
+from pyspark.sql.types import StructType
 from sparktestingbase.sqltestcase import SQLTestCase
 import unittest2
 
 
 class SimpleSQLTest(SQLTestCase):
     """A simple test."""
+
+    def test_empty_expected_equal(self):
+        allTypes = self.sc.parallelize([])
+        df = self.sqlCtx.createDataFrame(allTypes, StructType([]))
+        self.assertDataFrameEqual(df, df)
 
     def test_simple_expected_equal(self):
         allTypes = self.sc.parallelize([Row(
@@ -67,6 +73,16 @@ class SimpleSQLTest(SQLTestCase):
         allTypes1 = self.sc.parallelize([Row(d=1.0)])
         allTypes2 = self.sc.parallelize([Row(d="1.0")])
         self.assertDataFrameEqual(allTypes1.toDF(), allTypes2.toDF(), 0.0001)
+
+    @unittest2.expectedFailure
+    def test_empty_dataframe_unequal(self):
+        allTypes = self.sc.parallelize([Row(
+            i=1, s="string", d=1.001, l=1,
+            b=True, list=[1, 2, 3], dict={"s": 0}, row=Row(a=1),
+            time=datetime(2014, 8, 1, 14, 1, 5))])
+        empty = self.sc.parallelize([])
+        self.assertDataFrameEqual(allTypes.toDF(), self.sqlCtx.createDataFrame(empty, allTypes.toDF().schema), 0.1)
+
 
 if __name__ == "__main__":
     unittest2.main()


### PR DESCRIPTION
assertDataFrameEqual testcase passes when one of the DataFrame is empty fixed.