### PR TITLE
Loggin fix

### DIFF
--- a/src/main/1.3/scala/com/holdenkarau/spark/testing/StreamingSuiteCommon.scala
+++ b/src/main/1.3/scala/com/holdenkarau/spark/testing/StreamingSuiteCommon.scala
@@ -244,7 +244,7 @@ private[holdenkarau] trait StreamingSuiteCommon extends Logging
     val startTime = System.currentTimeMillis()
     while (output.size < numExpectedOutput &&
       System.currentTimeMillis() - startTime < maxWaitTimeMillis) {
-      logInfo("output.size = ${output.size}, expected = ${numExpectedOutput}")
+      logInfo(s"output.size = ${output.size}, expected = ${numExpectedOutput}")
       ssc.awaitTerminationOrTimeout(50)
     }
     val timeTaken = System.currentTimeMillis() - startTime


### PR DESCRIPTION
Logging for output size verification will now print output size and expected output size.