### PR TITLE
Allow users to change spark session config in DataFrameSuiteBase

### DIFF
--- a/src/main/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteBase.scala
+++ b/src/main/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteBase.scala
@@ -109,6 +109,8 @@ trait DataFrameSuiteBaseLike extends SparkContextProvider
       }
 
       val builder = newBuilder()
+     
+      extendBuilder(builder)
 
       SparkSessionProvider._sparkSession = builder.getOrCreate()
     }
@@ -163,6 +165,14 @@ trait DataFrameSuiteBaseLike extends SparkContextProvider
 
   def approxEquals(r1: Row, r2: Row, tol: Double): Boolean = {
     DataFrameSuiteBase.approxEquals(r1, r2, tol)
+  }
+
+  /**
+   * Gives users a chance to extend DataFrameSuiteBase and 
+   * change the default settings of the session
+   */
+  def extendBuilder(builder: SparkSession.Builder) = {
+  
   }
 }
 


### PR DESCRIPTION
I ran into a situation where I needed to change the spark session config, but I couldn't do it very cleanly due to newBuilder being a nested method and a few other reasons. 

So I added an overridable method, *extendBuilder(builder: SparkSession.builder)* that gets called before the session is made.