### PR TITLE
print unequal rows side by side

### DIFF
--- a/src/main/1.3/scala/com/holdenkarau/spark/testing/TestSuite.scala
+++ b/src/main/1.3/scala/com/holdenkarau/spark/testing/TestSuite.scala
@@ -17,6 +17,9 @@ trait TestSuite extends TestSuiteLike { self: Suite =>
 
   def assert[U](message: String, expected: U, actual: U)(implicit CT: ClassTag[U]) =
     org.scalatest.Assertions.assert(expected === actual, message)
+
+  override def fail(message: String): Unit =
+    org.scalatest.Assertions.fail(message)
 }
 
 trait JavaTestSuite extends TestSuiteLike {
@@ -33,6 +36,9 @@ trait JavaTestSuite extends TestSuiteLike {
 
   def assert[U](message: String, expected: U, actual: U)(implicit CT: ClassTag[U]) =
     org.junit.Assert.assertEquals(message, expected, actual)
+
+  override def fail(message: String): Unit =
+    org.junit.Assert.fail(message)
 }
 
 trait TestSuiteLike {
@@ -43,5 +49,7 @@ trait TestSuiteLike {
   def assertTrue(expected: Boolean)
 
   def assert[U](message: String, expected: U, actual: U)(implicit CT: ClassTag[U])
+
+  def fail(message: String)
 }
 

--- a/src/main/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteBase.scala
+++ b/src/main/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteBase.scala
@@ -20,15 +20,15 @@ package com.holdenkarau.spark.testing
 import java.io.File
 import java.sql.Timestamp
 
-import org.apache.hadoop.hive.conf.HiveConf
-import org.apache.hadoop.hive.conf.HiveConf.ConfVars
-import org.apache.spark.rdd.RDD
-import org.apache.spark.sql._
-import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
-import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.scalatest.Suite
 
 import scala.math.abs
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql._
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
+import org.apache.hadoop.hive.conf.HiveConf
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars
 
 /**
  * :: Experimental ::


### PR DESCRIPTION
Hi, 

The changes present in the pr make it possible to show the expected vs actual rows, one under the other in a `dataframe.show()` format. This should help figuring out what columns are not matching between dataframes