### PR TITLE
Setting Shuffle Partitions in order to limit the number of Tasks

### DIFF
--- a/src/main/1.3/scala/com/holdenkarau/spark/testing/SparkContextProvider.scala
+++ b/src/main/1.3/scala/com/holdenkarau/spark/testing/SparkContextProvider.scala
@@ -32,6 +32,7 @@ trait SparkContextProvider {
       set("spark.ui.enabled", "false").
       set("spark.app.id", appID).
       set("spark.driver.host", "localhost")
+      set("spark.sql.shuffle.partitions", "1")
   }
 
 


### PR DESCRIPTION
Significant reduce of memory usage and execution time.