### PR TITLE
Upgrade Ubuntu version in build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 sudo: required
-dist: precise
+dist: xenial
 cache:
   directories:
     - $HOME/.ivy2

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ cache:
     - $HOME/.pip-cache
     - $HOME/.sbt/launchers
 jdk:
-  - oraclejdk8
+  - openjdk8
 scala:
-   - 2.10.4
+   - 2.10.7
 sudo: false
 addons:
   apt:


### PR DESCRIPTION
Ubuntu 12.04  is unmaintained since April of 2017. It also produces warning in Travis. This pull request upgrades Ubuntu to 16.04.