### PR TITLE
Fix bug in DF equality comparison and simplify implementation

### DIFF
--- a/core/src/test/1.3/scala/com/holdenkarau/spark/testing/SampleDataFrameTest.scala
+++ b/core/src/test/1.3/scala/com/holdenkarau/spark/testing/SampleDataFrameTest.scala
@@ -79,6 +79,9 @@ class SampleDataFrameTest extends FunSuite with DataFrameSuiteBase {
     intercept[org.scalatest.exceptions.TestFailedException] {
       assertDataFrameEquals(input, input2)
     }
+    intercept[org.scalatest.exceptions.TestFailedException] {
+      assertDataFrameNoOrderEquals(input, input2)
+    }
   }
 
   test("unequal dataframe with different order should not equal") {


### PR DESCRIPTION
Fixes #318 

There's currently a sneaky bug in `assertDataFrameDataEquals` (and hence
`assertDataFrameNoOrderEquals`) because it uses Spark's non-null-safe
equality comparison. Specifically, the `.filter` in:

```
  val diff = expectedElementsCount
    .join(resultElementsCount, expected.columns, "full_outer")
    .filter(col(expectedCol) =!= col(actualCol))
```

will only keep rows where both `expectedCol` and `actualCol` are
non-null. Thus, if a row is present once in the `expected` DF, and not present in
the `result`, the `actualCol` will be `null` and this will cause the
column to be removed and not be reported as a difference.

The test I've added fails with the current implementation.

I've also replaced the implementation with a shorter version that uses
Spark 2.4's `intersectAll` directly. I think this version is slightly
simpler to follow because it uses set operations directly.

I'm not sure how the versioning works - I see that there are different
folders in `core/src/main`. Should I put the new implementation in a
`2.4` folder since it uses 2.4-specific functions? If so, do we also
need to backport a fix for older versions as well?

Alternatively, we could fix the current version by using the null-safe
equality comparison (`! ( <=> )` seems to do the job), or do both -
fix the equality comparison for pre-2.4, and use the implementation here
for 2.4. Let me know if this is preferable.

cc @holdenk