### PR TITLE
Adds columns size assertion in DataFrameSuiteBaseLike.assertDataFrame…

### DIFF
--- a/core/src/main/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteBase.scala
+++ b/core/src/main/2.0/scala/com/holdenkarau/spark/testing/DataFrameSuiteBase.scala
@@ -175,6 +175,7 @@ trait DataFrameSuiteBaseLike extends SparkContextProvider
     try {
       expected.rdd.cache
       result.rdd.cache
+      assert("Column size not Equal", expected.columns.size, result.columns.size)
       assert("Length not Equal", expected.rdd.count, result.rdd.count)
 
       val columns = expected.columns.map(s => col(s))

--- a/core/src/test/2.0/scala/com/holdenkarau/spark/testing/SampleDataFrameTest.scala
+++ b/core/src/test/2.0/scala/com/holdenkarau/spark/testing/SampleDataFrameTest.scala
@@ -193,6 +193,20 @@ class SampleDataFrameTest extends FunSuite with DataFrameSuiteBase {
     assertDataFrameDataEquals(df1, df2)
   }
 
+  test("assertDataFrameDataEquals fails dataframes with different columns size") {
+    val df1 = rowDf(
+      "a" -> (IntegerType, 1),
+      "b" -> (StringType, "a string"))
+    val df2 = rowDf(
+      "b" -> (StringType, "a string"),
+      "a" -> (IntegerType, 1),
+      "c" -> (IntegerType, 1))
+    val thrown = intercept[Exception] {
+      assertDataFrameDataEquals(df1, df2)
+    }
+    assert(thrown.getMessage contains "Column size not Equal")
+  }
+
   test("equal DF of rows of bytes should be equal (see GH issue #247)") {
     val df = rowDf(
       "a" -> (BinaryType, "bytes".getBytes()),


### PR DESCRIPTION
assertDataFrameDataEquals asserts two DataFrames with different columns size true. Asserting columns size at the beginning of the functions fixes the error.

Expected : 
```scala
test("assertDataFrameDataEquals fails dataframes with different columns size") {
   val df1 = rowDf(
     "a" -> (IntegerType, 1),
     "b" -> (StringType, "a string"))
   val df2 = rowDf(
     "b" -> (StringType, "a string"),
     "a" -> (IntegerType, 1),
     "c" -> (IntegerType, 1))
   val thrown = intercept[Exception] {
     assertDataFrameDataEquals(df1, df2)
   }
   assert(thrown.getMessage contains "Column size not Equal")
}
```
