### PR TITLE
Update ScalaFix & Remove dependency on Multisets

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,6 @@
-lazy val scala212 = "2.12.16"
-lazy val scala213 = "2.13.9"
-lazy val supportedScalaVersions = List(scala212, scala213)
-
 lazy val root = (project in file("."))
   .aggregate(core, kafka_0_8)
-  .settings(noPublishSettings, noCrossVersionSettings, commonSettings)
+  .settings(noPublishSettings, commonSettings)
 
 val sparkVersion = settingKey[String]("Spark version")
 val sparkTestingVersion = settingKey[String]("Spark testing base version without Spark version part")
@@ -73,20 +69,12 @@ lazy val kafka_0_8 = {
 val commonSettings = Seq(
   organization := "com.holdenkarau",
   publishMavenStyle := true,
-  scalaVersion := scala212,
-  skip in compile := {
-    scalaVersion.value >= "2.13.0" && sparkVersion.value <= "3.2.0"
-  },
-  skip in test := {
-    scalaVersion.value >= "2.13.0" && sparkVersion.value <= "3.2.0"
-  },
-  skip in publish := {
-    scalaVersion.value >= "2.13.0" && sparkVersion.value <= "3.2.0"
-  },
-  supportedCrossScalaSettings,
   sparkVersion := System.getProperty("sparkVersion", "2.4.0"),
   sparkTestingVersion := "1.1.2",
   version := sparkVersion.value + "_" + sparkTestingVersion.value,
+  scalaVersion := {
+    "2.12.12"
+  },
   scalacOptions ++= Seq("-deprecation", "-unchecked", "-Yrangepos", "-Ywarn-unused-import"),
   javacOptions ++= {
     Seq("-source", "1.8", "-target", "1.8")
@@ -203,9 +191,3 @@ lazy val publishSettings = Seq(
 
 lazy val noPublishSettings =
   skip in publish := true
-
-lazy val noCrossVersionSettings =
-  crossScalaVersions := Nil
-
-lazy val supportedCrossScalaSettings =
-  crossScalaVersions := supportedScalaVersions

--- a/build.sbt
+++ b/build.sbt
@@ -148,7 +148,6 @@ val coreTestSources = unmanagedSourceDirectories in Test  := {
 lazy val commonDependencies = Seq(
   "org.scalatest" %% "scalatest" % "3.1.1",
   "org.scalatestplus" %% "scalatestplus-scalacheck" % "3.1.0.0-RC2",
-  "io.github.nicolasstucki" %% "multisets" % "0.4",
   "org.scalacheck" %% "scalacheck" % "1.14.0",
   "junit" % "junit" % "4.12",
   "org.eclipse.jetty" % "jetty-util" % "9.3.11.v20160721",

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,10 @@
+lazy val scala212 = "2.12.16"
+lazy val scala213 = "2.13.9"
+lazy val supportedScalaVersions = List(scala212, scala213)
+
 lazy val root = (project in file("."))
   .aggregate(core, kafka_0_8)
-  .settings(noPublishSettings, commonSettings)
+  .settings(noPublishSettings, noCrossVersionSettings, commonSettings)
 
 val sparkVersion = settingKey[String]("Spark version")
 val sparkTestingVersion = settingKey[String]("Spark testing base version without Spark version part")
@@ -69,12 +73,20 @@ lazy val kafka_0_8 = {
 val commonSettings = Seq(
   organization := "com.holdenkarau",
   publishMavenStyle := true,
+  scalaVersion := scala212,
+  skip in compile := {
+    scalaVersion.value >= "2.13.0" && sparkVersion.value <= "3.2.0"
+  },
+  skip in test := {
+    scalaVersion.value >= "2.13.0" && sparkVersion.value <= "3.2.0"
+  },
+  skip in publish := {
+    scalaVersion.value >= "2.13.0" && sparkVersion.value <= "3.2.0"
+  },
+  supportedCrossScalaSettings,
   sparkVersion := System.getProperty("sparkVersion", "2.4.0"),
   sparkTestingVersion := "1.1.2",
   version := sparkVersion.value + "_" + sparkTestingVersion.value,
-  scalaVersion := {
-    "2.12.12"
-  },
   scalacOptions ++= Seq("-deprecation", "-unchecked", "-Yrangepos", "-Ywarn-unused-import"),
   javacOptions ++= {
     Seq("-source", "1.8", "-target", "1.8")
@@ -192,3 +204,9 @@ lazy val publishSettings = Seq(
 
 lazy val noPublishSettings =
   skip in publish := true
+
+lazy val noCrossVersionSettings =
+  crossScalaVersions := Nil
+
+lazy val supportedCrossScalaSettings =
+  crossScalaVersions := supportedScalaVersions

--- a/core/src/main/2.0/scala/com/holdenkarau/spark/testing/JavaStreamingSuitebase.scala
+++ b/core/src/main/2.0/scala/com/holdenkarau/spark/testing/JavaStreamingSuitebase.scala
@@ -69,7 +69,8 @@ class JavaStreamingSuiteBase extends JavaSuiteBase with StreamingSuiteCommon {
 
         compareArrays[V](
           expectedOutput(i).toArray,
-          output(i).toArray
+          output(i).toArray,
+          true
         )
       }
     }

--- a/core/src/main/2.0/scala/com/holdenkarau/spark/testing/JavaStreamingSuitebase.scala
+++ b/core/src/main/2.0/scala/com/holdenkarau/spark/testing/JavaStreamingSuitebase.scala
@@ -16,18 +16,15 @@
  */
 package com.holdenkarau.spark.testing
 
-import java.util.{List => JList}
-
-import org.apache.spark.api.java.function.{
-  Function => JFunction, Function2 => JFunction2}
+import org.apache.spark.SparkConf
+import org.apache.spark.api.java.function.{Function => JFunction, Function2 => JFunction2}
 import org.apache.spark.streaming.api.java._
 import org.apache.spark.streaming.dstream.DStream
 import org.junit.Assert._
 
+import java.util.{List => JList}
 import scala.collection.JavaConversions._
-import scala.collection.immutable.{HashBag => Bag}
 import scala.reflect.ClassTag
-import org.apache.spark.SparkConf
 
 /**
  * This is the base trait for Spark Streaming testsuite. This provides basic
@@ -69,10 +66,11 @@ class JavaStreamingSuiteBase extends JavaSuiteBase with StreamingSuiteCommon {
       if (ordered) {
         compareArrays[V](expectedOutput(i).toArray, output(i).toArray)
       } else {
-        implicit val config = Bag.configuration.compact[V]
+
         compareArrays[V](
-          Bag(expectedOutput(i): _*).toArray,
-          Bag(output(i): _*).toArray)
+          expectedOutput(i).toArray,
+          output(i).toArray
+        )
       }
     }
 

--- a/core/src/main/2.0/scala/com/holdenkarau/spark/testing/JavaSuiteBase.scala
+++ b/core/src/main/2.0/scala/com/holdenkarau/spark/testing/JavaSuiteBase.scala
@@ -16,14 +16,19 @@
  */
 package com.holdenkarau.spark.testing
 
+import breeze.linalg.NumericOps.Arrays
 import org.junit.Assert._
+import spire.ClassTag
+
+import java.util
 
 class JavaSuiteBase extends SharedJavaSparkContext {
   /**
    * Utility wrapper around assertArrayEquals that resolves the types
    */
-  def compareArrays[U](i1: Array[U], i2: Array[U]): Unit = {
-    (i1, i2) match {
+  def compareArrays[U: ClassTag](i1: Array[U], i2: Array[U], sorted: Boolean = false): Unit = {
+    val (arr1, arr2) = if(sorted) (copyAndSort(i1), copyAndSort(i2)) else (i1, i2)
+    (arr1, arr2) match {
       case (a1: Array[Long], a2: Array[Long]) => assertArrayEquals(a1, a2)
       case (a1: Array[Int], a2: Array[Int]) => assertArrayEquals(a1, a2)
       case (a1: Array[Short], a2: Array[Short]) => assertArrayEquals(a1, a2)
@@ -31,5 +36,19 @@ class JavaSuiteBase extends SharedJavaSparkContext {
       case (a1: Array[Byte], a2: Array[Byte]) => assertArrayEquals(a1, a2)
       case (a1: Array[Object], a2: Array[Object]) => assertArrayEquals(a1, a2)
     }
+  }
+
+  def copyAndSort[U: ClassTag](array: Array[U]): Array[U] = {
+    val copyArray = Array.ofDim[U](array.length)
+    Array.copy(array, 0, copyArray, 0, array.length)
+    copyArray match {
+      case a: Array[Long] => util.Arrays.sort(a)
+      case a: Array[Int] => util.Arrays.sort(a)
+      case a: Array[Short] => util.Arrays.sort(a)
+      case a: Array[Char] => util.Arrays.sort(a)
+      case a: Array[Byte] => util.Arrays.sort(a)
+      case a: Array[Object] => util.Arrays.sort(a)
+    }
+    copyArray
   }
 }

--- a/core/src/test/2.0/java/com/holdenkarau/spark/testing/SampleJavaStreamingTest.java
+++ b/core/src/test/2.0/java/com/holdenkarau/spark/testing/SampleJavaStreamingTest.java
@@ -29,12 +29,21 @@ public class SampleJavaStreamingTest extends JavaStreamingSuiteBase implements S
 
   @Test
   public void verifyFilterTest() {
-    List<List<Integer>> input = Arrays.asList(Arrays.asList(1, 2), Arrays.asList(3, 4, 5));
-    List<List<Integer>> expectedOutput = Arrays.asList(Arrays.asList(2), Arrays.asList(4));
+    List<List<Integer>> input = Arrays.asList(Arrays.asList(1, 2, 4, 8, 15, 22), Arrays.asList(3, 4, 5));
+    List<List<Integer>> expectedOutput = Arrays.asList(Arrays.asList(4, 2, 8, 22), Arrays.asList(4));
 
     testOperation(input, filterOddOperation, expectedOutput);
     testOperation(input, filterOddOperation, expectedOutput, true);
   }
+
+  @Test
+  public void verifyIncorrectOrderPasses() {
+    List<List<Integer>> input = Arrays.asList(Arrays.asList(1, 2, 4, 8, 15, 22), Arrays.asList(3, 4, 5, 80));
+    List<List<Integer>> expectedOutput = Arrays.asList(Arrays.asList(4, 2, 8, 22), Arrays.asList(80, 4));
+
+    testOperation(input, filterOddOperation, expectedOutput);
+  }
+
 
   @Test(expected = java.lang.AssertionError.class)
   public void wrongUnaryOperation() {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,4 +8,4 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.21")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.3")


### PR DESCRIPTION
This PR updates Scalafix to a newer version, it additionally replaces `HashBag` sorting with manual Java-based sorting. While this is definitely a little less pretty it reduces our dependency on `multisets`, which is required to allow us to support Scala 2.13.