### PR TITLE
Add support for use assertDataFrameDataEquals with map types

### DIFF
--- a/core/src/main/2.4/scala/com/holdenkarau/spark/testing/DataFrameSuiteBase.scala
+++ b/core/src/main/2.4/scala/com/holdenkarau/spark/testing/DataFrameSuiteBase.scala
@@ -415,8 +415,27 @@ Columns aren't equal
   } 
 
   /**
-    * Modify map type to an array of struct for having the possibility of compare
-    * the two dataframes.
+    * Converts map-typed columns into array-of-struct columns so that [[DataFrame]]s
+    * containing maps can be compared reliably in tests.
+    *
+    * Spark does not define a stable ordering for values of map type, which means that
+    * operations used in test assertions (such as set-like comparisons that ignore
+    * row order) cannot directly rely on map columns being orderable. This helper
+    * normalizes map columns into an orderable representation before comparison.
+    *
+    * For each map column, this method produces an array of structs created by
+    * zipping the map keys and values via `arrays_zip(map_keys(col), map_values(col))`.
+    * In the resulting struct, field `"0"` holds the key and field `"1"` holds the
+    * corresponding value. Non-map columns are preserved as-is.
+    *
+    * The transformation is applied recursively to nested structures: maps inside
+    * structs, arrays of structs containing maps, and other combinations are all
+    * rewritten so that every map encountered in the schema is converted to an
+    * array of structs in this way.
+    *
+    * The method is marked `private[testing]` because it is an internal utility of
+    * the testing framework, intended to support DataFrame equality checks rather
+    * than to be part of the public API.
     */
   private[testing] def convertMapToArrayStruct(df: DataFrame): DataFrame = {
     def buildExpr(dataType: DataType, colName: String): String = dataType match {

--- a/core/src/main/2.4/scala/com/holdenkarau/spark/testing/DataFrameSuiteBase.scala
+++ b/core/src/main/2.4/scala/com/holdenkarau/spark/testing/DataFrameSuiteBase.scala
@@ -412,7 +412,7 @@ Columns aren't equal
       expectedPostMap.rdd.unpersist()
       resultPostMap.rdd.unpersist()
     }
-  } 
+  }
 
   /**
     * Converts map-typed columns into array-of-struct columns so that [[DataFrame]]s

--- a/core/src/main/2.4/scala/com/holdenkarau/spark/testing/DataFrameSuiteBase.scala
+++ b/core/src/main/2.4/scala/com/holdenkarau/spark/testing/DataFrameSuiteBase.scala
@@ -429,6 +429,10 @@ Columns aren't equal
         s"named_struct($inner) AS $colName"
       case ArrayType(elementType, _) =>
         elementType match {
+          case MapType(_, _, _) =>
+            val mapExpr =
+              s"arrays_zip(map_keys(x), map_values(x))"
+            s"flatten(transform($colName, x -> $mapExpr)) AS $colName"
           case StructType(fields) =>
             val structExpr =
               fields.map(f =>

--- a/core/src/test/2.4/scala/com/holdenkarau/spark/testing/SampleDataFrameTest.scala
+++ b/core/src/test/2.4/scala/com/holdenkarau/spark/testing/SampleDataFrameTest.scala
@@ -381,7 +381,57 @@ class SampleDataFrameTest extends ScalaDataFrameSuiteBase {
 
     assertDataFrameEquals(expectedDF.orderBy("zip"), resultDF.orderBy("zip"))
   }
+  
+  test("AssertDataFrameEquals with map types should execute without thwros an exception") {
+   val inputSeq1 = Seq(
+     PandasMap("panda", "zipper", 22,30, Map("one" -> "1")),
+     PandasMap("panda", "zipper", 22,30, Map("one" -> "1"))
+   )
+
+    import sqlContext.implicits._
+    val input = inputSeq1.toDF()
+    val input2 = inputSeq1.toDF()
+    assertDataFrameDataEquals(input, input2)
+
+    val inputSeq2 = Seq(
+      TotalClass(
+        Array("1","2","3"),
+        inputSeq1.toArray,
+        PandasMap("panda", "zipper", 22,30, Map("one" -> "1")),
+        Map("one" -> 1, "two" -> 2, "three" -> 3),
+        Pandas("wiza", "10010", 20, 4)
+        )
+    ) 
+    val input3 = inputSeq2.toDF()
+    val input4 = inputSeq2.toDF()
+
+
+    assertDataFrameDataEquals(input3, input4)
+
+    val inputSeq3 = Seq(
+      TotalClass(
+        Array("1","2","3"),
+        inputSeq1.toArray,
+        PandasMap("panda", "zipper", 22,30, Map("one" -> "2")),
+        Map("one" -> 1, "two" -> 2, "three" -> 3),
+        Pandas("wiza", "10010", 20, 4)
+        )
+    ) 
+    val input5 = inputSeq3.toDF()
+    intercept[org.scalatest.exceptions.TestFailedException] {
+      assertDataFrameNoOrderEquals(input3, input5)
+    }
+  } 
+
 }
 
 case class Magic(name: String, power: Double, byteArray: Array[Byte])
 case class IntMagic(name: String, power: Int, byteArray: Array[Byte])
+case class PandasMap(name : String, zip : String, pandasSize: Integer, age : Int, person : Map[String, String])
+case class TotalClass(
+  normalArray : Array[String],
+  pandasArray : Array[PandasMap],
+  pandas : PandasMap,
+  mapType : Map[String, Int],
+  pandasNormal : Pandas
+)

--- a/core/src/test/2.4/scala/com/holdenkarau/spark/testing/SampleDataFrameTest.scala
+++ b/core/src/test/2.4/scala/com/holdenkarau/spark/testing/SampleDataFrameTest.scala
@@ -388,9 +388,11 @@ class SampleDataFrameTest extends ScalaDataFrameSuiteBase {
     val originalDF = Seq(
       BigTestClass(
         simpleMap = Map("one" -> 1, "two" -> 2),
-        arrayOfStruct = Array(InnerStruct("x", 10), InnerStruct("y", 20)),
+        arrayOfStruct = Array(
+          InnerStruct("x", 10, Map("one" -> 1)),
+          InnerStruct("y", 20, Map("one" -> 1))),
         nestedStruct = DeepStruct(
-        nested = InnerStruct("deep", 9),
+        nested = InnerStruct("deep", 9, Map("one" -> 1)),
         numbers = Array(1, 2, 3),
         meta = Map("k1" -> "v1")
         )
@@ -402,6 +404,7 @@ class SampleDataFrameTest extends ScalaDataFrameSuiteBase {
     val resultDF = convertMapToArrayStruct(originalDF)
     resultDF.show(false)
 
+   
     val expectedSchema = StructType(Seq(
     StructField(
       "simpleMap",
@@ -419,7 +422,18 @@ class SampleDataFrameTest extends ScalaDataFrameSuiteBase {
       ArrayType(
         StructType(Seq(
           StructField("a", StringType, nullable = true),
-          StructField("b", IntegerType, nullable = true)
+          StructField("b", IntegerType, nullable = true),
+          StructField(
+            "c",
+            ArrayType(
+              StructType(Seq(
+                StructField("0", StringType, nullable = true),
+                StructField("1", IntegerType, nullable = true)
+              )),
+              containsNull = false
+            ),
+            nullable = true
+          )
         )),
         containsNull = false
       ),
@@ -432,7 +446,18 @@ class SampleDataFrameTest extends ScalaDataFrameSuiteBase {
           "nested",
           StructType(Seq(
             StructField("a", StringType, nullable = true),
-            StructField("b", IntegerType, nullable = true)
+            StructField("b", IntegerType, nullable = true),
+            StructField(
+              "c",
+              ArrayType(
+                StructType(Seq(
+                  StructField("0", StringType, nullable = true),
+                  StructField("1", IntegerType, nullable = true)
+                )),
+                containsNull = false
+              ),
+              nullable = true
+            )
           )),
           nullable = false
         ),
@@ -456,7 +481,7 @@ class SampleDataFrameTest extends ScalaDataFrameSuiteBase {
       nullable = false
     )
     ))
-
+   
     assert(expectedSchema == resultDF.schema)
 
   }
@@ -467,9 +492,11 @@ class SampleDataFrameTest extends ScalaDataFrameSuiteBase {
     val originalDF = Seq(
       BigTestClass(
         simpleMap = Map("one" -> 1, "two" -> 2),
-        arrayOfStruct = Array(InnerStruct("x", 10), InnerStruct("y", 20)),
+        arrayOfStruct = Array(
+          InnerStruct("x", 10, Map("one"-> 1)),
+          InnerStruct("y", 20, Map("one"-> 1))),
         nestedStruct = DeepStruct(
-        nested = InnerStruct("deep", 9),
+        nested = InnerStruct("deep", 9, Map("one"-> 1)),
         numbers = Array(1, 2, 3),
         meta = Map("k1" -> "v1")
         )
@@ -483,9 +510,11 @@ class SampleDataFrameTest extends ScalaDataFrameSuiteBase {
     val modifiedDF = Seq(
       BigTestClass(
         simpleMap = Map("one" -> 999, "two" -> 2), // Here comes the difference
-        arrayOfStruct = Array(InnerStruct("x", 10), InnerStruct("y", 20)),
+        arrayOfStruct = Array(
+          InnerStruct("x", 10, Map("one"-> 1)),
+          InnerStruct("y", 20, Map("one"-> 1))),
         nestedStruct = DeepStruct(
-        nested = InnerStruct("deep", 9),
+        nested = InnerStruct("deep", 9, Map("one"-> 1)),
         numbers = Array(1, 2, 3),
         meta = Map("k1" -> "v1")
         )
@@ -503,7 +532,7 @@ class SampleDataFrameTest extends ScalaDataFrameSuiteBase {
 case class Magic(name: String, power: Double, byteArray: Array[Byte])
 case class IntMagic(name: String, power: Int, byteArray: Array[Byte])
 
-case class InnerStruct(a: String, b: Int)
+case class InnerStruct(a: String, b: Int, c: Map[String, Int])
 case class DeepStruct(
     nested: InnerStruct,
     numbers: Array[Int],

--- a/core/src/test/2.4/scala/com/holdenkarau/spark/testing/SampleDataFrameTest.scala
+++ b/core/src/test/2.4/scala/com/holdenkarau/spark/testing/SampleDataFrameTest.scala
@@ -400,10 +400,7 @@ class SampleDataFrameTest extends ScalaDataFrameSuiteBase {
       )
     ).toDF()
 
-    originalDF.show(false)
-
     val resultDF = convertMapToArrayStruct(originalDF)
-    resultDF.show(false)
 
    
     val expectedSchema = StructType(Seq(

--- a/core/src/test/2.4/scala/com/holdenkarau/spark/testing/SampleDataFrameTest.scala
+++ b/core/src/test/2.4/scala/com/holdenkarau/spark/testing/SampleDataFrameTest.scala
@@ -382,7 +382,7 @@ class SampleDataFrameTest extends ScalaDataFrameSuiteBase {
     assertDataFrameEquals(expectedDF.orderBy("zip"), resultDF.orderBy("zip"))
   }
 
-  test("convertMapToArrayStruct should return a schema with struct type instead a map"){
+  test("convertMapToArrayStruct should return a schema with struct type instead of a map"){
 
     import sqlContext.implicits._
     val originalDF = Seq(
@@ -516,10 +516,10 @@ class SampleDataFrameTest extends ScalaDataFrameSuiteBase {
       )
     ).toDF()
 
-    //Same dataframes should be equals
+    //Same dataframes should be equal
     assertDataFrameDataEquals(originalDF, originalDF)
 
-    //Part 2 test if detect properly differents dataframes
+    //Part 2: test that it correctly detects different dataframes
     val modifiedDF = Seq(
       BigTestClass(
         simpleMap = Map("one" -> 999, "two" -> 2), // Here comes the difference

--- a/core/src/test/2.4/scala/com/holdenkarau/spark/testing/SampleDataFrameTest.scala
+++ b/core/src/test/2.4/scala/com/holdenkarau/spark/testing/SampleDataFrameTest.scala
@@ -395,7 +395,8 @@ class SampleDataFrameTest extends ScalaDataFrameSuiteBase {
         nested = InnerStruct("deep", 9, Map("one" -> 1)),
         numbers = Array(1, 2, 3),
         meta = Map("k1" -> "v1")
-        )
+        ),
+        arrayMap = Array(Map("one" -> 1), Map("two" -> 2))
       )
     ).toDF()
 
@@ -479,7 +480,18 @@ class SampleDataFrameTest extends ScalaDataFrameSuiteBase {
         )
       )),
       nullable = false
-    )
+    ),
+    StructField(
+      "arrayMap",
+      ArrayType(
+        StructType(Seq(
+          StructField("0", StringType, nullable = true),
+          StructField("1", IntegerType, nullable = true)
+        )),
+        containsNull = false
+      ),
+      nullable = true
+      )
     ))
    
     assert(expectedSchema == resultDF.schema)
@@ -493,13 +505,14 @@ class SampleDataFrameTest extends ScalaDataFrameSuiteBase {
       BigTestClass(
         simpleMap = Map("one" -> 1, "two" -> 2),
         arrayOfStruct = Array(
-          InnerStruct("x", 10, Map("one"-> 1)),
-          InnerStruct("y", 20, Map("one"-> 1))),
+          InnerStruct("x", 10, Map("one" -> 1)),
+          InnerStruct("y", 20, Map("one" -> 1))),
         nestedStruct = DeepStruct(
-        nested = InnerStruct("deep", 9, Map("one"-> 1)),
+        nested = InnerStruct("deep", 9, Map("one" -> 1)),
         numbers = Array(1, 2, 3),
         meta = Map("k1" -> "v1")
-        )
+        ),
+        arrayMap = Array(Map("one" -> 1), Map("two" -> 2))
       )
     ).toDF()
 
@@ -511,13 +524,14 @@ class SampleDataFrameTest extends ScalaDataFrameSuiteBase {
       BigTestClass(
         simpleMap = Map("one" -> 999, "two" -> 2), // Here comes the difference
         arrayOfStruct = Array(
-          InnerStruct("x", 10, Map("one"-> 1)),
-          InnerStruct("y", 20, Map("one"-> 1))),
+          InnerStruct("x", 10, Map("one" -> 1)),
+          InnerStruct("y", 20, Map("one" -> 1))),
         nestedStruct = DeepStruct(
-        nested = InnerStruct("deep", 9, Map("one"-> 1)),
+        nested = InnerStruct("deep", 9, Map("one" -> 1)),
         numbers = Array(1, 2, 3),
         meta = Map("k1" -> "v1")
-        )
+        ),
+        arrayMap = Array(Map("one" -> 1), Map("two" -> 2))
       )
     ).toDF()
 
@@ -542,6 +556,7 @@ case class DeepStruct(
 case class BigTestClass(
     simpleMap: Map[String, Int],
     arrayOfStruct: Array[InnerStruct],
-    nestedStruct: DeepStruct
+    nestedStruct: DeepStruct,
+    arrayMap : Array[Map[String, Int]]
   )
 


### PR DESCRIPTION
References issue #444 

This changes propuse convert Map type in dataframe schema to array of struct for having the possibility for compare two dataframes. Due to MapType is not orderable.

I added the private method convertMapToArrayStruct which is compatible with all current Spark version, using sql expressions instead of Spark API. (We could move to Spark API in versions greater than 3.0.0) 

I also added two new test. 
- One is for see that the method converts properly the types into array of struct 
- Second one is for see the function assertDataFrameDataEquals works properly, compares the data and not raise and excepcion when map types is present into the dataframe.

All unit test are passed in my laptop, with differents Java version and in Github Actions.